### PR TITLE
feat: export baseUrl and apiKeys, types for openai compat

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -99,6 +99,10 @@ export class TinfoilAI {
   private groundTruth?: GroundTruth;
   private clientPromise: Promise<OpenAI>;
   private readyPromise?: Promise<void>;
+  
+  // Expose properties for compatibility
+  public apiKey?: string;
+  public baseURL?: string;
 
   /**
    * Creates a new TinfoilAI instance.
@@ -110,6 +114,10 @@ export class TinfoilAI {
     if (options.apiKey || process.env.TINFOIL_API_KEY) {
       openAIOptions.apiKey = options.apiKey || process.env.TINFOIL_API_KEY;
     }
+    
+    // Store properties for compatibility
+    this.apiKey = openAIOptions.apiKey;
+    this.baseURL = TINFOIL_CONFIG.INFERENCE_BASE_URL;
 
     this.clientPromise = this.initClient(openAIOptions);
   }
@@ -267,4 +275,22 @@ export class TinfoilAI {
   get beta(): Beta {
     return createAsyncProxy(this.ensureReady().then(client => client.beta));
   }
-} 
+}
+
+// Namespace declaration merge to add OpenAI types to TinfoilAI
+export namespace TinfoilAI {
+  // Re-export all OpenAI namespace types
+  export import Chat = OpenAI.Chat;
+  export import Audio = OpenAI.Audio;
+  export import Beta = OpenAI.Beta;
+  export import Batches = OpenAI.Batches;
+  export import Completions = OpenAI.Completions;
+  export import Embeddings = OpenAI.Embeddings;
+  export import Files = OpenAI.Files;
+  export import FineTuning = OpenAI.FineTuning;
+  export import Images = OpenAI.Images;
+  export import Models = OpenAI.Models;
+  export import Moderations = OpenAI.Moderations;
+  export import Uploads = OpenAI.Uploads;
+  export import VectorStores = OpenAI.VectorStores;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,30 @@
-export * from './client';
+// Re-export the TinfoilAI class
+export { TinfoilAI } from './client';
+export { TinfoilAI as default } from './client';
+
+// Export secure client and config
 export * from './secure-client';
 export * from './ai-sdk-provider';
 export * from './config';
+
+// Re-export OpenAI utility types and classes that users might need
+// Using public exports from the main OpenAI package instead of deep imports
+export {
+  type Uploadable,
+  toFile,
+  APIPromise,
+  PagePromise,
+  OpenAIError,
+  APIError,
+  APIConnectionError,
+  APIConnectionTimeoutError,
+  APIUserAbortError,
+  NotFoundError,
+  ConflictError,
+  RateLimitError,
+  BadRequestError,
+  AuthenticationError,
+  InternalServerError,
+  PermissionDeniedError,
+  UnprocessableEntityError,
+} from 'openai';


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Expose apiKey and baseURL on TinfoilAI and re-export OpenAI types/utilities for drop-in compatibility with the OpenAI client. This makes migration easier and unlocks access to common OpenAI helpers and error classes.

- New Features
  - Expose instance.apiKey and instance.baseURL for OpenAI-client compatibility.
  - Add TinfoilAI namespace exports (Chat, Audio, Beta, Batches, etc.) via declaration merging.
  - Re-export OpenAI utilities: Uploadable, toFile, APIPromise, PagePromise.
  - Re-export OpenAI error classes (e.g., APIError, RateLimitError).
  - Export TinfoilAI as both named and default from the package.

- Migration
  - Import TinfoilAI from the package root (default or named).
  - Access client.apiKey and client.baseURL if your code expects these fields.
  - Import OpenAI helpers and errors directly from the package root.

<!-- End of auto-generated description by cubic. -->

