### PR TITLE
Fix: use GitHub proxy to avoid rate limits

### DIFF
--- a/src/secure-client.ts
+++ b/src/secure-client.ts
@@ -146,7 +146,7 @@ export class SecureClient {
                 throw new Error('WASM functions not available');
             }
 
-            const releaseResponse = await fetch(`https://api.github.com/repos/${this.repo}/releases/latest`, {
+            const releaseResponse = await fetch(`https://api-github-proxy.tinfoil.sh/repos/${this.repo}/releases/latest`, {
                 headers: {
                     'Accept': 'application/vnd.github.v3+json',
                     'User-Agent': 'tinfoil-node-client'


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fetch the latest GitHub release via our api-github-proxy.tinfoil.sh to avoid GitHub API rate limits and stabilize release checks. Replaces the releases/latest endpoint in SecureClient with the proxy URL.

<!-- End of auto-generated description by cubic. -->

