### PR TITLE
Fix: remove browser dependencies 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tinfoil",
-  "version": "0.6.3",
+  "version": "0.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tinfoil",
-      "version": "0.6.3",
+      "version": "0.7.1",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@ai-sdk/openai-compatible": "^1.0.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tinfoil",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Tinfoil secure OpenAI client wrapper",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/secure-client.ts
+++ b/src/secure-client.ts
@@ -33,17 +33,6 @@ if (!globalThis.crypto) {
   };
 }
 
-// Modified secure-client.ts
-if (typeof window === "undefined") {
-  // Node.js environment
-  globalThis.window = globalThis as any;
-  globalThis.document = {
-    createElement: () => ({
-      setAttribute: () => {},
-    }),
-  };
-}
-
 // Force process to stay running (prevent Go from exiting Node process)
 // This is a common issue with Go WASM in Node - it calls process.exit()
 const originalExit = process.exit;


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Removed browser-only globals from secure-client to eliminate implicit window/document shims in Node. This fixes server/CLI runtime errors and avoids side effects from fake DOM globals.

- **Bug Fixes**
  - Deleted window/document polyfill in secure-client to run cleanly in Node and SSR environments.

- **Dependencies**
  - Bumped package version and refreshed lockfile.

<!-- End of auto-generated description by cubic. -->

