### PR TITLE
chore: require Node 20.18.1+

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@
 
 A Node.js wrapper around the OpenAI client that verifies enclave attestation and certificate fingerprints when using Tinfoil inference.
 
+## Requirements
+
+Node 20.18.1 and higher.
+
 ## Installation
 
 ```bash
@@ -53,10 +57,6 @@ npx ts-node main.ts
 ```
 
 The example demonstrates streaming chat completions with the Tinfoil API wrapper.
-
-## Runtime Support
-
-Supports Node.js 18+, Deno, Bun, Cloudflare Workers, and more. Browser usage is disabled by default for security. See [OpenAI Node.js client](https://github.com/openai/openai-node) for complete runtime compatibility.
 
 ## API Documentation
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tinfoil",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tinfoil",
-      "version": "0.7.1",
+      "version": "0.7.2",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@ai-sdk/openai-compatible": "^1.0.10",
@@ -25,6 +25,9 @@
         "jest": "^29.7.0",
         "ts-jest": "^29.4.1",
         "typescript": "^5.9.2"
+      },
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/@ai-sdk/gateway": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,9 @@
   ],
   "author": "Tinfoil",
   "license": "AGPL-3.0-or-later",
+  "engines": {
+    "node": ">=20.18.1"
+  },
   "dependencies": {
     "@ai-sdk/openai-compatible": "^1.0.10",
     "ai": "^5.0.19",


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Raise the minimum Node.js version to 20.18.1+ and document the requirement. This enforces the engines field and removes outdated runtime support notes in the README.

- **Migration**
  - Use Node 20.18.1+ locally and in CI.
  - Reinstall dependencies after upgrading Node.

<!-- End of auto-generated description by cubic. -->

