### PR TITLE
Feat: support TLS fallback in Node.js

### DIFF
--- a/src/__tests__/client.inference-tinfoil.test.ts
+++ b/src/__tests__/client.inference-tinfoil.test.ts
@@ -12,7 +12,13 @@ describe("TinfoilAI - inference.tinfoil.sh integration", () => {
     }
 
     const { TinfoilAI } = await import("../client");
+    const API_KEY = process.env.TINFOIL_API_KEY || process.env.OPENAI_API_KEY;
+    if (!API_KEY) {
+      t.skip("Set TINFOIL_API_KEY or OPENAI_API_KEY for integration test.");
+      return;
+    }
     const client = new TinfoilAI({
+      apiKey: API_KEY,
       baseURL: "https://inference.tinfoil.sh/v1/",
       configRepo: "tinfoilsh/confidential-inference-proxy",
     });

--- a/src/__tests__/client.inference-tinfoil.test.ts
+++ b/src/__tests__/client.inference-tinfoil.test.ts
@@ -1,0 +1,41 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+
+const RUN_INTEGRATION = process.env.RUN_TINFOIL_INTEGRATION === "true";
+const SKIP_MESSAGE = "Set RUN_TINFOIL_INTEGRATION=true to enable network integration tests.";
+
+describe("TinfoilAI - inference.tinfoil.sh integration", () => {
+  it("should verify enclave with confidential-inference-proxy repo", async (t) => {
+    if (!RUN_INTEGRATION) {
+      t.skip(SKIP_MESSAGE);
+      return;
+    }
+
+    const { TinfoilAI } = await import("../client");
+    const client = new TinfoilAI({
+      baseURL: "https://inference.tinfoil.sh/v1/",
+      configRepo: "tinfoilsh/confidential-inference-proxy",
+    });
+
+    await client.ready();
+
+    // Get the verification document to ensure verification happened
+    const verificationDoc = await client.getVerificationDocument();
+    
+    assert.ok(verificationDoc, "Verification document should be available");
+    assert.strictEqual(verificationDoc.configRepo, "tinfoilsh/confidential-inference-proxy", "Should use confidential-inference-proxy repo");
+    assert.ok(verificationDoc.match, "Verification should match");
+    
+    // TLS fingerprint should always be available
+    assert.ok(verificationDoc.enclaveMeasurement.tlsPublicKeyFingerprint, "TLS public key fingerprint should be available");
+    
+    // HPKE is optional - if not available, TLS-only verification is used
+    if (verificationDoc.enclaveMeasurement.hpkePublicKey) {
+      console.log("HPKE public key available - using encrypted body transport");
+    } else {
+      console.log("HPKE not available - using TLS-only verification");
+    }
+
+    console.log("Verification document:", verificationDoc);
+  });
+});

--- a/src/__tests__/security.enforcement.test.ts
+++ b/src/__tests__/security.enforcement.test.ts
@@ -1,0 +1,130 @@
+import { describe, it } from "node:test";
+import type { TestContext } from "node:test";
+import assert from "node:assert";
+import { withMockedModules } from "./test-utils";
+import { encryptedBodyRequest, createEncryptedBodyFetch } from "../encrypted-body-fetch";
+
+const MOCK_FP = "a3b1c5d7e9f0a1b2c3d4e5f60718293a4b5c6d7e8f9a0b1c2d3e4f506172839a";
+
+describe("Security enforcement", () => {
+  it("EHBP helpers reject HTTP URLs and baseURL", async () => {
+    await assert.rejects(
+      encryptedBodyRequest("http://insecure.test/v1/models", "hpke-key"),
+      /HTTP connections are not allowed/i,
+    );
+
+    const create = () => createEncryptedBodyFetch("http://insecure.test/v1/", "hpke-key");
+    await assert.rejects(
+      (async () => {
+        const f = create();
+        await f("models");
+      })(),
+      /must use HTTPS|HTTP connections are not allowed/i,
+    );
+  });
+
+  it("TinfoilAI TLS fallback uses pinned fetch that rejects HTTP", async (t: TestContext) => {
+    const verifyMock = t.mock.fn(async () => ({
+      tlsPublicKeyFingerprint: MOCK_FP,
+      // No HPKE key triggers TLS fallback
+      measurement: { type: "eif", registers: [] },
+    }));
+
+    let capturedFetch: typeof fetch | undefined;
+    const openAIConstructorMock = t.mock.fn(function (this: unknown, options: { fetch?: typeof fetch }) {
+      capturedFetch = options.fetch;
+      return { options } as any;
+    });
+
+    await withMockedModules(
+      {
+        "./verifier": {
+          Verifier: class {
+            verify() {
+              return verifyMock();
+            }
+            getVerificationDocument() {
+              return {
+                repo: "owner/repo",
+                configRepo: "owner/repo",
+                enclaveHost: "insecure.test",
+                releaseDigest: "deadbeef",
+                codeMeasurement: { type: "eif", registers: [] },
+                enclaveMeasurement: {
+                  tlsPublicKeyFingerprint: MOCK_FP,
+                  measurement: { type: "eif", registers: [] },
+                },
+                match: true,
+              };
+            }
+          },
+        },
+        openai: Object.assign(openAIConstructorMock, { OpenAI: openAIConstructorMock }),
+      },
+      ["../client"],
+      async () => {
+        const { TinfoilAI } = await import("../client");
+        const client = new TinfoilAI({ apiKey: "key", baseURL: "https://secure.test/v1/" });
+        await client.ready();
+        assert.ok(capturedFetch, "Pinned TLS fetch should be provided in fallback");
+        await assert.rejects(
+          capturedFetch!("http://insecure.test/v1/models"),
+          /HTTP connections are not allowed/i,
+        );
+      },
+    );
+  });
+
+  it("AI SDK provider TLS fallback uses pinned fetch that rejects HTTP", async (t: TestContext) => {
+    const verifyMock = t.mock.fn(async () => ({
+      tlsPublicKeyFingerprint: MOCK_FP,
+      measurement: { type: "eif", registers: [] },
+    }));
+
+    let capturedFetch: typeof fetch | undefined;
+    const createOpenAICompatibleMock = t.mock.fn((options: { fetch: typeof fetch }) => {
+      capturedFetch = options.fetch;
+      return { __mockProvider: true } as any;
+    });
+
+    await withMockedModules(
+      {
+        "./verifier": {
+          Verifier: class {
+            verify() {
+              return verifyMock();
+            }
+            getVerificationDocument() {
+              return {
+                repo: "owner/repo",
+                configRepo: "owner/repo",
+                enclaveHost: "secure.test",
+                releaseDigest: "deadbeef",
+                codeMeasurement: { type: "eif", registers: [] },
+                enclaveMeasurement: {
+                  tlsPublicKeyFingerprint: MOCK_FP,
+                  measurement: { type: "eif", registers: [] },
+                },
+                match: true,
+              };
+            }
+          },
+        },
+        "@ai-sdk/openai-compatible": {
+          createOpenAICompatible: createOpenAICompatibleMock,
+        },
+      },
+      ["../ai-sdk-provider"],
+      async () => {
+        const { createTinfoilAI } = await import("../ai-sdk-provider");
+        await createTinfoilAI("key", { baseURL: "https://secure.test/v1/" });
+        assert.ok(capturedFetch, "Pinned TLS fetch should be provided in fallback provider");
+        await assert.rejects(
+          capturedFetch!("http://insecure.test/v1/models"),
+          /HTTP connections are not allowed/i,
+        );
+      },
+    );
+  });
+});
+

--- a/src/__tests__/verifier.test.ts
+++ b/src/__tests__/verifier.test.ts
@@ -139,7 +139,7 @@ describe("Verifier helpers", () => {
           const { loadVerifier } = await import("../verification-runner");
           const client = await loadVerifier();
 
-          await assert.rejects(() => client.verifyEnclave("host"), /Missing tls_public_key/);
+          await assert.rejects(() => client.verifyEnclave("host"), /Missing both tls_public_key and hpke_public_key/);
         },
       );
     } finally {

--- a/src/ai-sdk-provider.ts
+++ b/src/ai-sdk-provider.ts
@@ -2,31 +2,181 @@ import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
 import { TINFOIL_CONFIG } from "./config";
 import { createEncryptedBodyFetch } from "./encrypted-body-fetch";
 import { Verifier } from "./verifier";
+import { isRealBrowser } from "./env";
+import https from "node:https";
+import tls, { checkServerIdentity as tlsCheckServerIdentity } from "node:tls";
+import { X509Certificate, createHash } from "node:crypto";
+import { Readable } from "node:stream";
+import { ReadableStream as NodeReadableStream } from "node:stream/web";
+
+interface CreateTinfoilAIOptions {
+  /** Override the inference API base URL */
+  baseURL?: string;
+  /** Override the config GitHub repository */
+  configRepo?: string;
+}
 
 /**
  * Creates an AI SDK provider with the specified API key.
  *
  * @param apiKey - The API key for the Tinfoil API
+ * @param options - Optional configuration options
  * @returns A TinfoilAI instance
  */
-export async function createTinfoilAI(apiKey: string) {
+export async function createTinfoilAI(apiKey: string, options: CreateTinfoilAIOptions = {}) {
+  const baseURL = options.baseURL || TINFOIL_CONFIG.INFERENCE_BASE_URL;
+  const configRepo = options.configRepo || TINFOIL_CONFIG.INFERENCE_PROXY_REPO;
 
-  // step 1: verify the enclave and extract the hpke public key
+  assertHttpsUrl(baseURL, "Inference baseURL");
+
+  // step 1: verify the enclave and extract the public keys
   // from the attestation response
-  const verifier = new Verifier();
+  const verifier = new Verifier({ serverURL: baseURL, configRepo });
   const attestationResponse = await verifier.verify();
   const hpkePublicKey = attestationResponse.hpkePublicKey;
+  const tlsPublicKeyFingerprint = attestationResponse.tlsPublicKeyFingerprint;
 
-  // step 2: create an encrypted body fetch function
-  // that uses the hpke public key to encrypt the http body of the request
-  const encryptedBodyFetch = createEncryptedBodyFetch(TINFOIL_CONFIG.INFERENCE_BASE_URL, hpkePublicKey);
+  // step 2: create the appropriate fetch function based on available keys
+  let fetchFunction: typeof fetch;
+  
+  if (hpkePublicKey) {
+    // HPKE available: use encrypted body fetch
+    fetchFunction = createEncryptedBodyFetch(baseURL, hpkePublicKey);
+  } else {
+    // HPKE not available: check if we're in a browser
+    if (isRealBrowser()) {
+      throw new Error(
+        "HPKE public key not available and TLS-only verification is not supported in browsers. " +
+        "Only HPKE-enabled enclaves can be used in browser environments."
+      );
+    }
+    
+    // Node.js environment: fall back to TLS-only verification using pinned TLS fetch
+    fetchFunction = createPinnedTlsFetch(tlsPublicKeyFingerprint);
+  }
 
   // step 3: create the openai compatible provider
-  // that uses the encrypted body fetch function
+  // that uses the appropriate fetch function
   return createOpenAICompatible({
     name: "tinfoil",
-    baseURL: TINFOIL_CONFIG.INFERENCE_BASE_URL.replace(/\/$/, ""),
+    baseURL: baseURL.replace(/\/$/, ""),
     apiKey: apiKey,
-    fetch: encryptedBodyFetch,
+    fetch: fetchFunction,
   });
+}
+
+function assertHttpsUrl(url: string, context: string): void {
+  const parsed = new URL(url);
+  if (parsed.protocol !== "https:") {
+    throw new Error(`${context} must use HTTPS. Got: ${url}`);
+  }
+}
+
+function createPinnedTlsFetch(expectedFingerprintHex: string): typeof fetch {
+  return (async (input: RequestInfo | URL, init?: RequestInit) => {
+    // Normalize URL
+    const makeURL = (value: RequestInfo | URL): URL => {
+      if (typeof value === "string") return new URL(value);
+      if (value instanceof URL) return value;
+      return new URL((value as Request).url);
+    };
+
+    const url = makeURL(input);
+    if (url.protocol !== "https:") {
+      throw new Error(`HTTP connections are not allowed. Use HTTPS. URL: ${url.toString()}`);
+    }
+
+    // Gather method and headers
+    const method = (init?.method || (input as any).method || "GET").toUpperCase();
+    const headers = new Headers(init?.headers || (input as any)?.headers || {});
+    const headerObj: Record<string, string> = {};
+    headers.forEach((v, k) => {
+      headerObj[k] = v;
+    });
+
+    // Resolve body
+    let body: any = init?.body;
+    if (!body && input instanceof Request) {
+      // If the original was a Request with a body, read it
+      try {
+        const buf = await (input as Request).arrayBuffer();
+        if (buf && (buf as ArrayBuffer).byteLength) body = Buffer.from(buf as ArrayBuffer);
+      } catch {}
+    }
+    // Convert web streams to Node streams if needed
+    if (body && typeof (body as any).getReader === "function") {
+      body = Readable.fromWeb(body as unknown as NodeReadableStream);
+    }
+    if (body instanceof ArrayBuffer) {
+      body = Buffer.from(body);
+    }
+    if (ArrayBuffer.isView(body)) {
+      body = Buffer.from(body.buffer, body.byteOffset, body.byteLength);
+    }
+
+    const requestOptions: https.RequestOptions & tls.ConnectionOptions = {
+      protocol: url.protocol,
+      hostname: url.hostname,
+      port: url.port ? Number(url.port) : 443,
+      path: `${url.pathname}${url.search}`,
+      method,
+      headers: headerObj,
+      checkServerIdentity: (host, cert): Error | undefined => {
+        const raw = (cert as any).raw as Buffer | undefined;
+        if (!raw) {
+          return new Error("Certificate raw bytes are unavailable for pinning");
+        }
+        const x509 = new X509Certificate(raw);
+        const publicKeyDer = x509.publicKey.export({ type: "spki", format: "der" });
+        const fp = createHash("sha256").update(publicKeyDer).digest("hex");
+        if (fp !== expectedFingerprintHex) {
+          return new Error(`Certificate public key fingerprint mismatch. Expected: ${expectedFingerprintHex}, Got: ${fp}`);
+        }
+        return tlsCheckServerIdentity(host, cert);
+      },
+    };
+
+    const { signal } = init || {};
+
+    const res = await new Promise<import("node:http").IncomingMessage>((resolve, reject) => {
+      const req = https.request(requestOptions, resolve);
+      req.on("error", reject);
+      if (signal) {
+        if ((signal as AbortSignal).aborted) {
+          req.destroy(new Error("Request aborted"));
+          return;
+        }
+        (signal as AbortSignal).addEventListener("abort", () => req.destroy(new Error("Request aborted")));
+      }
+      if (body === undefined || body === null) {
+        req.end();
+      } else if (typeof body === "string" || Buffer.isBuffer(body) || ArrayBuffer.isView(body)) {
+        req.end(body as any);
+      } else if (typeof (body as any).pipe === "function") {
+        (body as any).pipe(req);
+      } else {
+        // Fallback: try to serialize objects
+        req.end(String(body));
+      }
+    });
+
+    const responseHeaders = new Headers();
+    for (const [k, v] of Object.entries(res.headers)) {
+      if (Array.isArray(v)) {
+        for (const item of v) responseHeaders.append(k, item);
+      } else if (typeof v === "string") {
+        responseHeaders.set(k, v);
+      } else if (typeof v === "number") {
+        responseHeaders.set(k, String(v));
+      }
+    }
+
+    // Convert Node stream to Web ReadableStream
+    const webStream = Readable.toWeb(res as unknown as import("node:stream").Readable) as unknown as ReadableStream;
+    return new Response(webStream, {
+      status: res.statusCode || 0,
+      statusText: res.statusMessage || "",
+      headers: responseHeaders,
+    });
+  }) as typeof fetch;
 }

--- a/src/ai-sdk-provider.ts
+++ b/src/ai-sdk-provider.ts
@@ -168,10 +168,8 @@ function createPinnedTlsFetch(expectedFingerprintHex: string): typeof fetch {
     const responseHeaders = new Headers();
     for (const [k, v] of Object.entries(res.headers)) {
       if (Array.isArray(v)) {
-        for (const item of v) responseHeaders.append(k, item);
-      } else if (typeof v === "string") {
-        responseHeaders.set(k, v);
-      } else if (typeof v === "number") {
+        v.forEach(item => responseHeaders.append(k, item));
+      } else if (v != null) {
         responseHeaders.set(k, String(v));
       }
     }

--- a/src/ai-sdk-provider.ts
+++ b/src/ai-sdk-provider.ts
@@ -3,11 +3,11 @@ import { TINFOIL_CONFIG } from "./config";
 import { createEncryptedBodyFetch } from "./encrypted-body-fetch";
 import { Verifier } from "./verifier";
 import { isRealBrowser } from "./env";
-import https from "node:https";
-import tls, { checkServerIdentity as tlsCheckServerIdentity } from "node:tls";
-import { X509Certificate, createHash } from "node:crypto";
-import { Readable } from "node:stream";
-import { ReadableStream as NodeReadableStream } from "node:stream/web";
+import https from "https";
+import tls, { checkServerIdentity as tlsCheckServerIdentity } from "tls";
+import { X509Certificate, createHash } from "crypto";
+import { Readable } from "stream";
+import { ReadableStream as NodeReadableStream } from "stream/web";
 
 interface CreateTinfoilAIOptions {
   /** Override the inference API base URL */
@@ -138,7 +138,7 @@ function createPinnedTlsFetch(expectedFingerprintHex: string): typeof fetch {
 
     const { signal } = init || {};
 
-    const res = await new Promise<import("node:http").IncomingMessage>((resolve, reject) => {
+    const res = await new Promise<import("http").IncomingMessage>((resolve, reject) => {
       const req = https.request(requestOptions, resolve);
       req.on("error", reject);
       if (signal) {
@@ -172,7 +172,7 @@ function createPinnedTlsFetch(expectedFingerprintHex: string): typeof fetch {
     }
 
     // Convert Node stream to Web ReadableStream
-    const webStream = Readable.toWeb(res as unknown as import("node:stream").Readable) as unknown as ReadableStream;
+    const webStream = Readable.toWeb(res as unknown as import("stream").Readable) as unknown as ReadableStream;
     return new Response(webStream, {
       status: res.statusCode || 0,
       statusText: res.statusMessage || "",

--- a/src/ai-sdk-provider.ts
+++ b/src/ai-sdk-provider.ts
@@ -52,6 +52,11 @@ export async function createTinfoilAI(apiKey: string, options: CreateTinfoilAIOp
     }
     
     // Node.js environment: fall back to TLS-only verification using pinned TLS fetch
+    if (!tlsPublicKeyFingerprint) {
+      throw new Error(
+        "Neither HPKE public key nor TLS public key fingerprint available for verification"
+      );
+    }
     fetchFunction = createPinnedTlsFetch(tlsPublicKeyFingerprint);
   }
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -432,10 +432,8 @@ function createPinnedTlsFetch(expectedFingerprintHex: string): typeof fetch {
     const responseHeaders = new Headers();
     for (const [k, v] of Object.entries(res.headers)) {
       if (Array.isArray(v)) {
-        for (const item of v) responseHeaders.append(k, item);
-      } else if (typeof v === "string") {
-        responseHeaders.set(k, v);
-      } else if (typeof v === "number") {
+        v.forEach(item => responseHeaders.append(k, item));
+      } else if (v != null) {
         responseHeaders.set(k, String(v));
       }
     }

--- a/src/client.ts
+++ b/src/client.ts
@@ -16,11 +16,11 @@ import type { AttestationResponse } from "./verifier";
 import type { VerificationDocument } from "./verifier";
 import { TINFOIL_CONFIG } from "./config";
 import { createEncryptedBodyFetch } from "./encrypted-body-fetch";
-import https from "node:https";
-import tls, { checkServerIdentity as tlsCheckServerIdentity } from "node:tls";
-import { X509Certificate, createHash } from "node:crypto";
-import { Readable } from "node:stream";
-import { ReadableStream as NodeReadableStream } from "node:stream/web";
+import https from "https";
+import tls, { checkServerIdentity as tlsCheckServerIdentity } from "tls";
+import { X509Certificate, createHash } from "crypto";
+import { Readable } from "stream";
+import { ReadableStream as NodeReadableStream } from "stream/web";
 
 /**
  * Detects if the code is running in a real browser environment.
@@ -402,7 +402,7 @@ function createPinnedTlsFetch(expectedFingerprintHex: string): typeof fetch {
 
     const { signal } = init || {};
 
-    const res = await new Promise<import("node:http").IncomingMessage>((resolve, reject) => {
+    const res = await new Promise<import("http").IncomingMessage>((resolve, reject) => {
       const req = https.request(requestOptions, resolve);
       req.on("error", reject);
       if (signal) {
@@ -436,7 +436,7 @@ function createPinnedTlsFetch(expectedFingerprintHex: string): typeof fetch {
     }
 
     // Convert Node stream to Web ReadableStream
-    const webStream = Readable.toWeb(res as unknown as import("node:stream").Readable) as unknown as ReadableStream;
+    const webStream = Readable.toWeb(res as unknown as import("stream").Readable) as unknown as ReadableStream;
     return new Response(webStream, {
       status: res.statusCode || 0,
       statusText: res.statusMessage || "",

--- a/src/client.ts
+++ b/src/client.ts
@@ -180,6 +180,11 @@ export class TinfoilAI {
       }
       
       // Node.js environment: fall back to TLS-only verification using pinned TLS fetch
+      if (!tlsPublicKeyFingerprint) {
+        throw new Error(
+          "Neither HPKE public key nor TLS public key fingerprint available for verification"
+        );
+      }
       fetchFunction = createPinnedTlsFetch(tlsPublicKeyFingerprint);
     }
 

--- a/src/encrypted-body-fetch.ts
+++ b/src/encrypted-body-fetch.ts
@@ -46,7 +46,11 @@ export async function encryptedBodyRequest(
     init,
   );
 
-  const { origin } = new URL(requestUrl);
+  const u = new URL(requestUrl);
+  if (u.protocol !== 'https:') {
+    throw new Error(`HTTP connections are not allowed for EHBP. Use HTTPS. URL: ${requestUrl}`);
+  }
+  const { origin } = u;
   const transport = await getTransportForOrigin(origin);
 
   const serverPublicKey = await transport.getServerPublicKeyHex();
@@ -60,6 +64,10 @@ export async function encryptedBodyRequest(
 
 export function createEncryptedBodyFetch(baseURL: string, hpkePublicKey: string): typeof fetch {
   return (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const base = new URL(baseURL);
+    if (base.protocol !== 'https:') {
+      throw new Error(`EHBP baseURL must use HTTPS. Got: ${baseURL}`);
+    }
     const normalized = normalizeEncryptedBodyRequestArgs(input, init);
     const targetUrl = new URL(normalized.url, baseURL);
 
@@ -104,6 +112,10 @@ async function getTransportForOrigin(origin: string): Promise<EhbpTransport> {
 
   const transportPromise = (async () => {
     const { Identity, createTransport } = await getEhbpModule();
+    const proto = new URL(origin).protocol;
+    if (proto !== 'https:') {
+      throw new Error(`EHBP requires HTTPS origin. Got: ${origin}`);
+    }
     
     // Ensure we're in a secure context with WebCrypto Subtle available (required by EHBP)
     if (typeof globalThis !== 'undefined') {

--- a/src/verifier.ts
+++ b/src/verifier.ts
@@ -348,39 +348,81 @@ export class Verifier {
    * @returns Attestation response with measurement and keys
    */
   public async verifyEnclave(enclaveHost?: string): Promise<AttestationResponse> {
-    const targetHost = enclaveHost || this.serverURL;
-    
-    await Verifier.initializeWasm();
-    
-    if (typeof globalThis.verifyEnclave !== "function") {
-      throw new Error("WASM verifyEnclave function not available");
-    }
-    
-    const attestationResponse = await globalThis.verifyEnclave(targetHost);
-    
-    // Validate required fields
-    if (!attestationResponse.tls_public_key) {
-      throw new Error('Missing tls_public_key in attestation response');
-    }
-    if (!attestationResponse.hpke_public_key) {
-      throw new Error('Missing hpke_public_key in attestation response');
-    }
-    
-    // Parse runtime measurement
-    let parsedRuntimeMeasurement: AttestationMeasurement;
-    if (attestationResponse.measurement && typeof attestationResponse.measurement === 'string') {
-      parsedRuntimeMeasurement = JSON.parse(attestationResponse.measurement);
-    } else if (attestationResponse.measurement && typeof attestationResponse.measurement === 'object') {
-      parsedRuntimeMeasurement = attestationResponse.measurement;
-    } else {
-      throw new Error('Invalid runtime measurement format');
-    }
-    
-    return {
-      tlsPublicKeyFingerprint: attestationResponse.tls_public_key,
-      hpkePublicKey: attestationResponse.hpke_public_key,
-      measurement: parsedRuntimeMeasurement,
-    };
+    // Expose errors via explicit Promise rejection and add a timeout
+    return new Promise(async (resolve, reject) => {
+      try {
+        const targetHost = enclaveHost || this.serverURL;
+
+        await Verifier.initializeWasm();
+
+        if (typeof globalThis.verifyEnclave !== "function") {
+          reject(new Error("WASM verifyEnclave function not available"));
+          return;
+        }
+
+        let attestationResponse: any;
+        try {
+          const timeoutPromise = new Promise((_, timeoutReject) =>
+            setTimeout(
+              () => timeoutReject(new Error("WASM verifyEnclave timed out after 10 seconds")),
+              10000,
+            ),
+          );
+
+          attestationResponse = await Promise.race([
+            (globalThis as any).verifyEnclave(targetHost),
+            timeoutPromise,
+          ]);
+        } catch (error) {
+          reject(new Error(`WASM verifyEnclave failed: ${error}`));
+          return;
+        }
+
+        // Validate required fields - fail fast with explicit rejection
+        if (!attestationResponse?.tls_public_key) {
+          reject(new Error("Missing tls_public_key in attestation response"));
+          return;
+        }
+        if (!attestationResponse?.hpke_public_key) {
+          reject(
+            new Error(
+              "Missing hpke_public_key in attestation response - EHBP not supported by this enclave",
+            ),
+          );
+          return;
+        }
+
+        // Parse runtime measurement
+        let parsedRuntimeMeasurement: AttestationMeasurement;
+        try {
+          if (
+            attestationResponse.measurement &&
+            typeof attestationResponse.measurement === "string"
+          ) {
+            parsedRuntimeMeasurement = JSON.parse(attestationResponse.measurement);
+          } else if (
+            attestationResponse.measurement &&
+            typeof attestationResponse.measurement === "object"
+          ) {
+            parsedRuntimeMeasurement = attestationResponse.measurement;
+          } else {
+            reject(new Error("Invalid runtime measurement format"));
+            return;
+          }
+        } catch (parseError) {
+          reject(new Error(`Failed to parse runtime measurement: ${parseError}`));
+          return;
+        }
+
+        resolve({
+          tlsPublicKeyFingerprint: attestationResponse.tls_public_key,
+          hpkePublicKey: attestationResponse.hpke_public_key,
+          measurement: parsedRuntimeMeasurement,
+        });
+      } catch (outerError) {
+        reject(outerError as Error);
+      }
+    });
   }
   
   /**


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Add TLS-only fallback when HPKE is unavailable in Node by pinning the server’s TLS public key fingerprint. Enforces HTTPS-only across EHBP and fallback fetch; browsers still require HPKE.

- **New Features**
  - TLS fallback in client and AI SDK provider using a pinned TLS fetch (fingerprint from attestation).
  - Verifier: hpkePublicKey is optional, added timeout/error surfacing for verifyEnclave, and kept repo in verification doc for compatibility.

- **Bug Fixes**
  - Enforced HTTPS-only: reject HTTP in EHBP requests, baseURL, and pinned TLS fetch.
  - Added tests for TLS fallback and HTTPS enforcement.

<!-- End of auto-generated description by cubic. -->

