### PR TITLE
feat: support node 20+

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ npm install tinfoil
 
 ## Requirements
 
-Node 20.18.1 and higher.
+Node 20+.
 
 ## Quick Start
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "typescript": "^5.9.2"
       },
       "engines": {
-        "node": ">=20.18.1"
+        "node": ">=20"
       }
     },
     "node_modules/@ai-sdk/gateway": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "author": "Tinfoil",
   "license": "AGPL-3.0-or-later",
   "engines": {
-    "node": ">=20.18.1"
+    "node": ">=20"
   },
   "dependencies": {
     "@ai-sdk/openai-compatible": "^1.0.10",

--- a/src/verifier.ts
+++ b/src/verifier.ts
@@ -25,7 +25,7 @@
  * - All verification executes locally via WebAssembly (Go → WASM)
  * - WASM loader: `wasm-exec.js`
  * - WASM module URL: https://tinfoilsh.github.io/verifier-js/tinfoil-verifier.wasm
- * - Works in Node 20.18.1+ and modern browsers with lightweight polyfills for
+ * - Works in Node 20+ and modern browsers with lightweight polyfills for
  *   `performance`, `TextEncoder`/`TextDecoder`, and `crypto.getRandomValues`
  * - Go stdout/stderr is suppressed by default; toggle via `suppressWasmLogs()`
  * - Successful end-to-end results are cached per `configRepo::enclave::digest` for the process lifetime


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Loosened Node requirement to 20+ to broaden compatibility across all Node 20.x versions. Updated engines in package.json/package-lock, README, and a comment in verifier.ts; no runtime behavior changes.

<!-- End of auto-generated description by cubic. -->

