### PR TITLE
feat: add verification center ui to package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,8 @@
       },
       "devDependencies": {
         "@types/node": "^24.3.0",
+        "@types/react": "^19.1.16",
+        "@types/react-dom": "^19.1.9",
         "@typescript-eslint/eslint-plugin": "^8.40.0",
         "@typescript-eslint/parser": "^8.40.0",
         "eslint": "^8.57.0",
@@ -26,6 +28,34 @@
       },
       "engines": {
         "node": ">=20"
+      },
+      "peerDependencies": {
+        "@heroicons/react": "*",
+        "@xyflow/react": "*",
+        "framer-motion": "*",
+        "react": "^18 || ^19",
+        "react-dom": "^18 || ^19",
+        "react-icons": "*"
+      },
+      "peerDependenciesMeta": {
+        "@heroicons/react": {
+          "optional": true
+        },
+        "@xyflow/react": {
+          "optional": true
+        },
+        "framer-motion": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "react-icons": {
+          "optional": true
+        }
       }
     },
     "node_modules/@ai-sdk/gateway": {
@@ -523,6 +553,24 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.10.0"
+      }
+    },
+    "node_modules/@types/react": {
+      "version": "19.1.16",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.16.tgz",
+      "integrity": "sha512-WBM/nDbEZmDUORKnh5i1bTnAz6vTohUf9b8esSMu+b24+srbaxa04UbJgWx78CVfNXA20sNu0odEIluZDFdCog==",
+      "dev": true,
+      "dependencies": {
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "19.1.9",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.1.9.tgz",
+      "integrity": "sha512-qXRuZaOsAdXKFyOhRBg6Lqqc0yay13vN7KrIg4L7N4aaHN68ma9OK3NE1BoDFgFOTfM7zg+3/8+2n8rLUH3OKQ==",
+      "dev": true,
+      "peerDependencies": {
+        "@types/react": "^19.0.0"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -1055,6 +1103,12 @@
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
       "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true
+    },
+    "node_modules/csstype": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
       "dev": true
     },
     "node_modules/data-urls": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "types": "dist/index.d.ts",
   "browser": {
     "./dist/index.js": "./dist/esm/index.browser.js",
-    "./dist/esm/index.js": "./dist/esm/index.browser.js"
+    "./dist/esm/index.js": "./dist/esm/index.browser.js",
+    "./dist/verification-center/index.js": "./dist/esm/verification-center/index.js"
   },
   "exports": {
     ".": {
@@ -43,12 +44,18 @@
       "types": "./dist/config.d.ts",
       "import": "./dist/esm/config.js",
       "require": "./dist/config.js"
+    },
+    "./verification-center": {
+      "types": "./dist/verification-center/index.d.ts",
+      "require": "./dist/verification-center/index.js",
+      "import": "./dist/esm/verification-center/index.js",
+      "default": "./dist/verification-center/index.js"
     }
   },
   "scripts": {
     "build": "npm run build:cjs && npm run build:esm",
-    "build:cjs": "tsc && cp src/wasm-exec.js dist/",
-    "build:esm": "tsc -p tsconfig.esm.json && cp src/wasm-exec.js dist/esm/",
+    "build:cjs": "tsc && cp src/wasm-exec.js dist/ && rsync -a --include='*/' --include='*.css' --exclude='*' src/verification-center/ dist/verification-center/ || true",
+    "build:esm": "tsc -p tsconfig.esm.json && cp src/wasm-exec.js dist/esm/ && rsync -a --include='*/' --include='*.css' --exclude='*' src/verification-center/ dist/esm/verification-center/ || true",
     "test": "bash -lc 'rm -rf .node-tests && tsc -p tsconfig.node-test.json && cp src/wasm-exec.js .node-tests/ && node --test $(find .node-tests -name \"*.test.js\" -print)'",
     "lint": "eslint src/**/*.ts",
     "prepublishOnly": "npm run build"
@@ -81,12 +88,45 @@
     "openai": "^5.13.1",
     "ts-node": "^10.9.2"
   },
+  "peerDependencies": {
+    "@heroicons/react": "*",
+    "@xyflow/react": "*",
+    "framer-motion": "*",
+    "react": "^18 || ^19",
+    "react-dom": "^18 || ^19",
+    "react-icons": "*"
+  },
+  "peerDependenciesMeta": {
+    "react": {
+      "optional": true
+    },
+    "react-dom": {
+      "optional": true
+    },
+    "@xyflow/react": {
+      "optional": true
+    },
+    "@heroicons/react": {
+      "optional": true
+    },
+    "react-icons": {
+      "optional": true
+    },
+    "framer-motion": {
+      "optional": true
+    }
+  },
   "devDependencies": {
     "@types/node": "^24.3.0",
+    "@types/react": "^19.1.16",
+    "@types/react-dom": "^19.1.9",
     "@typescript-eslint/eslint-plugin": "^8.40.0",
     "@typescript-eslint/parser": "^8.40.0",
     "eslint": "^8.57.0",
     "jsdom": "^25.0.0",
     "typescript": "^5.9.2"
-  }
+  },
+  "sideEffects": [
+    "**/*.css"
+  ]
 }

--- a/src/verification-center/ambient.d.ts
+++ b/src/verification-center/ambient.d.ts
@@ -1,0 +1,69 @@
+// Minimal ambient module declarations to allow building the optional UI
+// while keeping third-party UI peer deps optional.
+
+declare module '@xyflow/react' {
+  export const ReactFlowProvider: any
+  export interface ReactFlowProps {
+    nodes?: any[]
+    edges?: any[]
+    onNodesChange?: (changes: any) => void
+    onEdgesChange?: (changes: any) => void
+    nodeTypes?: any
+    edgeTypes?: any
+    defaultEdgeOptions?: any
+    fitView?: boolean
+    onInit?: (instance: any) => void
+    nodesDraggable?: boolean
+    nodesConnectable?: boolean
+    elementsSelectable?: boolean
+    zoomOnScroll?: boolean
+    zoomOnPinch?: boolean
+    panOnDrag?: boolean
+    preventScrolling?: boolean
+    proOptions?: any
+    children?: any
+  }
+  export function ReactFlow(props: ReactFlowProps): any
+  export const Background: any
+  export enum BackgroundVariant { Dots }
+  export function useEdgesState<T = any>(initial?: T[]): [
+    T[],
+    (updater: T[] | ((eds: T[]) => T[])) => void,
+    (changes: any) => void,
+  ]
+  export function useNodesState<T = any>(initial?: T[]): [
+    T[],
+    (updater: T[] | ((nds: T[]) => T[])) => void,
+    (changes: any) => void,
+  ]
+  export function useReactFlow(): any
+  export const Handle: any
+  export const Position: any
+  export function getBezierPath(...args: any[]): any
+  export type Edge = any
+  export type EdgeProps<T = any> = any
+  export type Node<T = any> = any
+  export type NodeProps<T = any> = any
+}
+
+declare module '@heroicons/react/24/outline' {
+  export const ChevronDownIcon: any
+  export const ShieldCheckIcon: any
+  export const ExclamationTriangleIcon: any
+  export const CheckIcon: any
+  export const XMarkIcon: any
+}
+
+declare module 'react-icons/ai' { export const AiOutlineLoading3Quarters: any }
+declare module 'react-icons/fa' { export const FaGithub: any; export const FaUser: any }
+declare module 'react-icons/lu' { export const LuExternalLink: any; export const LuRefreshCcwDot: any; export const LuBrain: any; export const LuCpu: any }
+declare module 'react-icons/io5' { export const IoCodeSlashOutline: any }
+declare module 'react-icons/bs' { export const BsDiagram3: any }
+declare module 'react-icons/fi' { export const FiGithub: any; export const FiKey: any; export const FiShield: any }
+
+declare module 'framer-motion' {
+  export const motion: any
+  export const AnimatePresence: any
+}
+
+declare module '*.css'

--- a/src/verification-center/flow/collapsible-flow-diagram.tsx
+++ b/src/verification-center/flow/collapsible-flow-diagram.tsx
@@ -1,0 +1,93 @@
+'use client'
+
+import { ChevronDownIcon } from '@heroicons/react/24/outline'
+import React, { useId, useState } from 'react'
+import { BsDiagram3 } from 'react-icons/bs'
+
+type CollapsibleFlowDiagramProps = {
+  children: React.ReactNode
+  isDarkMode?: boolean
+  isExpanded?: boolean
+  onToggle?: () => void
+}
+
+export function CollapsibleFlowDiagram({
+  children,
+  isDarkMode = true,
+  isExpanded: controlledIsExpanded,
+  onToggle,
+}: CollapsibleFlowDiagramProps) {
+  const [internalIsExpanded, setInternalIsExpanded] = useState(false)
+  const isExpanded = controlledIsExpanded ?? internalIsExpanded
+  const contentId = useId()
+
+  return (
+    <div
+      className={`w-full rounded-lg border @container ${
+        isDarkMode ? 'border-gray-700' : 'border-gray-200 bg-white'
+      }`}
+    >
+      <button
+        type="button"
+        onClick={() => {
+          if (onToggle) {
+            onToggle()
+          } else {
+            setInternalIsExpanded(!internalIsExpanded)
+          }
+        }}
+        className="w-full p-4 text-left"
+        aria-expanded={isExpanded}
+        aria-controls={contentId}
+      >
+        <div className="flex flex-row items-center gap-3 md:gap-4">
+          <div className="flex items-center">
+            <BsDiagram3
+              className={`h-6 w-6 ${isDarkMode ? 'text-white' : 'text-gray-600'}`}
+            />
+          </div>
+
+          <div className="flex-1 text-center @[400px]:text-left">
+            <h3
+              className={`text-sm font-medium ${isDarkMode ? 'text-gray-100' : 'text-gray-900'}`}
+            >
+              Verification Flow Diagram
+            </h3>
+            <p
+              className={`hidden text-sm @[400px]:block ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}
+            >
+              Visual representation of the verification process and data flow
+            </p>
+          </div>
+
+          <div
+            className={`rounded-lg p-2 ${isDarkMode ? 'hover:bg-gray-700' : 'hover:bg-gray-100'}`}
+          >
+            <ChevronDownIcon
+              className={`h-5 w-5 transition-transform ${
+                isDarkMode ? 'text-gray-400' : 'text-gray-500'
+              } ${isExpanded ? 'rotate-180' : ''}`}
+            />
+          </div>
+        </div>
+      </button>
+
+      <div
+        id={contentId}
+        className={`${isDarkMode ? 'border-gray-700' : 'border-gray-200'} ${
+          isExpanded ? 'border-t' : 'border-t-0'
+        } overflow-hidden transition-all duration-300 ease-in-out ${
+          isExpanded ? 'max-h-[1000px] opacity-100' : 'max-h-0 opacity-0'
+        }`}
+        aria-hidden={!isExpanded}
+      >
+        <div
+          className={`rounded-b-lg px-4 py-4 ${isDarkMode ? 'bg-gray-900' : 'bg-gray-50'}`}
+        >
+          {children}
+        </div>
+      </div>
+    </div>
+  )
+}
+

--- a/src/verification-center/flow/container-node.tsx
+++ b/src/verification-center/flow/container-node.tsx
@@ -1,0 +1,94 @@
+'use client'
+
+import type { Node, NodeProps } from '@xyflow/react'
+import { Handle, Position } from '@xyflow/react'
+import { memo } from 'react'
+
+type ContainerNodeData = {
+  title: string
+  icon?: React.ReactNode
+  containerId?: string
+}
+
+type ContainerNodeType = Node<ContainerNodeData>
+
+function ContainerNode({ data }: NodeProps<ContainerNodeType>) {
+  return (
+    <div
+      className="container-node"
+      id={data.containerId}
+      style={{
+        width: '100%',
+        height: '100%',
+      }}
+    >
+      <div className="container-header">
+        {data.icon && <div className="icon">{data.icon}</div>}
+        <div className="title">{data.title}</div>
+      </div>
+
+      <Handle
+        type="target"
+        position={Position.Top}
+        id="target-top"
+        className="connection-handle"
+        style={{ left: '50%' }}
+      />
+      <Handle
+        type="source"
+        position={Position.Top}
+        id="source-top"
+        className="connection-handle"
+        style={{ left: '50%' }}
+      />
+      <Handle
+        type="target"
+        position={Position.Bottom}
+        id="target-bottom"
+        className="connection-handle"
+        style={{ left: '50%' }}
+      />
+      <Handle
+        type="source"
+        position={Position.Bottom}
+        id="source-bottom"
+        className="connection-handle"
+        style={{ left: '50%' }}
+      />
+      <Handle
+        type="target"
+        position={Position.Left}
+        id="target-left"
+        className="connection-handle"
+        style={{ top: '50%' }}
+      />
+      <Handle
+        type="source"
+        position={Position.Left}
+        id="source-left"
+        className="connection-handle"
+        style={{ top: '50%' }}
+      />
+      <Handle
+        type="target"
+        position={Position.Right}
+        id="target-right"
+        className="connection-handle"
+        style={{ top: '50%' }}
+      />
+      <Handle
+        type="source"
+        position={Position.Right}
+        id="source-right"
+        className="connection-handle"
+        style={{ top: '50%' }}
+      />
+    </div>
+  )
+}
+
+ContainerNode.displayName = 'ContainerNode'
+
+export type { ContainerNodeType }
+export default memo(ContainerNode)
+

--- a/src/verification-center/flow/flow.css
+++ b/src/verification-center/flow/flow.css
@@ -1,0 +1,440 @@
+/* Limit styles to the diagram only so we don't override global site styles */
+.react-flow * {
+  box-sizing: border-box;
+  /* Safari/Firefox specific resets for consistent rendering */
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+/* Disable initial load animations for child nodes */
+.react-flow__node[data-id='ai-model'] {
+  animation: none !important;
+  transition: none !important;
+}
+
+/* Also disable for attestation node to prevent initial layout shift */
+.react-flow__node[data-id='attestation'] {
+  animation: none !important;
+  transition: none !important;
+}
+
+.react-flow__node[data-id='ai-model']:hover {
+  transition:
+    box-shadow 0.2s ease,
+    transform 0.1s ease !important;
+}
+
+.react-flow {
+  --bg-color: transparent;
+  --text-color: hsl(var(--foreground));
+  --node-border-radius: 20px;
+  --node-border-color: rgba(70, 130, 180, 0.15);
+  --node-box-shadow: 0 3px 10px rgba(0, 0, 0, 0.08);
+  background-color: var(--bg-color);
+  color: var(--text-color);
+  font-family: var(--font-sans);
+}
+
+.container-node {
+  position: absolute;
+  border-radius: var(--node-border-radius);
+  padding: 2px;
+  background: hsl(var(--surface-card) / 0.7);
+  border: 1px solid rgba(16, 185, 129, 0.3);
+  box-shadow: var(--node-box-shadow);
+  z-index: -1;
+  transition: border 0.2s ease;
+  overflow: hidden;
+}
+
+.container-node:before {
+  display: none;
+}
+
+.container-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 12px 16px 8px;
+  color: var(--text-color);
+  font-family: var(--font-sans);
+  font-weight: 500;
+  letter-spacing: -0.2px;
+  background-color: hsl(var(--surface-card) / 0.7);
+  margin: -2px;
+  border-top-left-radius: var(--node-border-radius);
+  border-top-right-radius: var(--node-border-radius);
+}
+
+.container-header .icon {
+  display: flex;
+  align-items: center;
+  color: var(--text-color);
+}
+
+.container-header .title {
+  font-size: 18px;
+  font-weight: 600;
+  opacity: 0.9;
+}
+
+.react-flow__node-turbo {
+  border-radius: var(--node-border-radius);
+  display: flex;
+  height: 70px;
+  min-width: 150px;
+  font-family: var(--font-sans);
+  font-weight: 500;
+  letter-spacing: -0.2px;
+  border: 1px solid var(--node-border-color);
+  box-shadow: var(--node-box-shadow);
+  cursor: default;
+  background-color: hsl(var(--surface-card));
+  overflow: hidden;
+  transition:
+    box-shadow 0.2s ease,
+    transform 0.1s ease;
+}
+
+/* Dark mode node styling */
+.dark .react-flow__node-turbo {
+  background-color: hsl(var(--gray-700));
+  border: 1px solid rgba(156, 163, 175, 0.3);
+}
+
+.react-flow__node-turbo:hover {
+  box-shadow: 0 5px 15px rgba(0, 0, 0, 0.1);
+  transform: translateY(-1px);
+}
+
+.react-flow__node-turbo .wrapper {
+  overflow: hidden;
+  display: flex;
+  padding: 2px;
+  position: relative;
+  border-radius: calc(var(--node-border-radius) - 2px);
+  border: 1px solid rgba(70, 130, 180, 0.08);
+  flex-grow: 1;
+}
+
+.gradient:before {
+  display: none;
+}
+
+.react-flow__node-turbo.selected .wrapper.gradient:before {
+  display: none;
+}
+
+@keyframes spinner {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+}
+
+.react-flow__node-turbo .inner {
+  background: hsl(var(--surface-card));
+  padding: 16px 20px;
+  border-radius: calc(var(--node-border-radius) - 4px);
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  flex-grow: 1;
+  position: relative;
+  z-index: 1;
+}
+
+/* Dark mode inner styling */
+.dark .react-flow__node-turbo .inner {
+  background: hsl(var(--gray-700));
+}
+
+.react-flow__node-turbo .icon {
+  margin-right: 8px;
+}
+
+.react-flow__node-turbo .body {
+  display: flex;
+}
+
+.react-flow__node-turbo .title {
+  font-size: 16px;
+  margin-bottom: 2px;
+  line-height: 1;
+}
+
+.react-flow__node-turbo .subtitle {
+  font-size: 13px;
+  color: hsl(var(--muted-foreground));
+}
+
+/* Dark mode text styling */
+.dark .react-flow__node-turbo .title {
+  color: hsl(var(--content-primary));
+}
+
+.dark .react-flow__node-turbo .subtitle {
+  color: hsl(var(--content-secondary));
+}
+
+.react-flow__node-turbo .cloud {
+  border-radius: 100%;
+  width: 30px;
+  height: 30px;
+  right: 0;
+  position: absolute;
+  top: 0;
+  transform: translate(50%, -50%);
+  display: flex;
+  transform-origin: center center;
+  padding: 2px;
+  overflow: hidden;
+  border: 1px solid var(--node-border-color);
+  box-shadow: none;
+  z-index: 1;
+}
+
+.react-flow__node-turbo .cloud div {
+  background-color: hsl(var(--surface-card));
+  flex-grow: 1;
+  border-radius: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  position: relative;
+}
+
+.react-flow__handle {
+  opacity: 0;
+  width: 10px;
+  height: 10px;
+  background-color: transparent;
+  border: none;
+}
+
+/* Reset the default left/right positioning that's causing problems */
+.react-flow__handle.source,
+.react-flow__handle.target {
+  left: auto;
+  right: auto;
+  transform: none;
+  opacity: 0 !important;
+}
+
+/* Make all handles properly positioned but invisible */
+.react-flow__handle-right.connection-handle {
+  right: -10px;
+  left: auto;
+  transform: translateY(-50%);
+  -webkit-transform: translateY(-50%);
+  -moz-transform: translateY(-50%);
+}
+
+.react-flow__handle-left.connection-handle {
+  left: -10px;
+  right: auto;
+  transform: translateY(-50%);
+  -webkit-transform: translateY(-50%);
+  -moz-transform: translateY(-50%);
+}
+
+.react-flow__handle-top.connection-handle {
+  top: -10px;
+  transform: translateX(-50%);
+  -webkit-transform: translateX(-50%);
+  -moz-transform: translateX(-50%);
+}
+
+.react-flow__handle-bottom.connection-handle {
+  bottom: -10px;
+  transform: translateX(-50%);
+  -webkit-transform: translateX(-50%);
+  -moz-transform: translateX(-50%);
+}
+
+/* Custom styling for handles with connection markers */
+.connection-handle {
+  width: 10px;
+  height: 10px;
+  background-color: transparent;
+  border: none;
+  border-radius: 50%;
+  opacity: 0 !important;
+}
+
+.react-flow__node:focus {
+  outline: none;
+}
+
+.react-flow__edge .react-flow__edge-path {
+  stroke: rgba(80, 100, 120, 0.6);
+  stroke-width: 1.5;
+  stroke-opacity: 0.8;
+  stroke-dasharray: none;
+  marker-start: url(#circle-marker);
+  marker-end: url(#circle-marker);
+  transition: stroke 0.2s ease;
+  /* Safari/Firefox SVG rendering fix */
+  shape-rendering: geometricPrecision;
+  -webkit-backface-visibility: hidden;
+}
+
+/* Dark mode edge styling */
+.dark .react-flow__edge .react-flow__edge-path {
+  stroke: rgba(156, 163, 175, 0.6);
+}
+
+/* Edge markers */
+.react-flow__edge-marker {
+  fill: rgba(80, 100, 120, 0.8);
+  stroke: none;
+}
+
+/* Dark mode edge markers */
+.dark .react-flow__edge-marker {
+  fill: rgba(156, 163, 175, 0.8);
+}
+
+/* SVG definitions for markers */
+.react-flow__svg-definitions {
+  position: absolute;
+  width: 0;
+  height: 0;
+}
+
+.react-flow__svg-definitions defs {
+  display: block;
+}
+
+/* Custom marker styles */
+#circle-marker {
+  overflow: visible;
+}
+
+#circle-marker circle {
+  fill: rgba(80, 100, 120, 0.6);
+  r: 3;
+}
+
+/* Dark mode marker circles */
+.dark #circle-marker circle {
+  fill: rgba(156, 163, 175, 0.6);
+}
+
+.react-flow__controls {
+  display: flex;
+  flex-direction: column;
+  background-color: transparent;
+}
+
+.react-flow__controls button {
+  background-color: hsl(var(--surface-card));
+  color: hsl(var(--content-primary));
+  border: 1px solid #95679e;
+  border-bottom: none;
+}
+
+.react-flow__controls button:hover {
+  background-color: hsl(var(--surface-card) / 0.9);
+}
+
+.react-flow__controls button:first-child {
+  border-radius: 5px 5px 0 0;
+}
+
+.react-flow__controls button:last-child {
+  border-bottom: 1px solid #95679e;
+  border-radius: 0 0 5px 5px;
+}
+
+.react-flow__controls button path {
+  fill: var(--text-color);
+}
+
+.react-flow__background {
+  display: none;
+}
+
+.react-flow__attribution {
+  display: none;
+}
+
+.react-flow__minimap {
+  display: none;
+}
+
+/* Enclave node styling */
+.enclave-node .wrapper:before {
+  display: none;
+}
+
+.enclave-node .wrapper {
+  border: 1px solid rgba(42, 138, 246, 0.3);
+  border-radius: var(--node-border-radius);
+}
+
+.enclave-node .inner {
+  background-color: hsl(var(--surface-card));
+}
+
+/* Tinfoil Server container styling */
+#tinfoil-container {
+  background-color: rgba(107, 114, 128, 0.08) !important; /* gray-500/8 */
+  border: 1px solid rgba(0, 0, 0, 0.1) !important; /* subtle neutral border */
+}
+
+#tinfoil-container .container-header {
+  background-color: rgba(107, 114, 128, 0.08);
+}
+
+/* Client container styling */
+#client-container {
+  background-color: rgba(16, 185, 129, 0.05) !important;
+  border: 1px solid rgba(16, 185, 129, 0.2) !important;
+}
+
+#client-container .container-header {
+  background-color: rgba(16, 185, 129, 0.06);
+}
+
+/* Enclave container styling */
+#enclave-container {
+  background-color: rgba(16, 185, 129, 0.05) !important;
+  border: 1px solid rgba(16, 185, 129, 0.2) !important;
+}
+
+#enclave-container .container-header {
+  background-color: rgba(16, 185, 129, 0.06);
+}
+
+/* Secure Hardware container styling */
+#secure-hardware-container {
+  background-color: rgba(16, 185, 129, 0.05) !important;
+  border: 2px dashed rgba(16, 185, 129, 0.25) !important;
+  border-radius: 16px !important;
+}
+
+#secure-hardware-container .container-header {
+  background-color: rgba(16, 185, 129, 0.08);
+  color: rgba(0, 80, 80, 0.9);
+  font-weight: 600;
+  font-size: 14px;
+  padding: 8px 12px 6px;
+}
+
+/* Dark mode: white text for better visibility */
+.dark #secure-hardware-container .container-header {
+  color: hsl(var(--content-primary));
+}
+
+#secure-hardware-container .container-header .icon {
+  color: rgba(0, 80, 80, 0.8);
+}
+
+/* Dark mode: white icon for consistency */
+.dark #secure-hardware-container .container-header .icon {
+  color: hsl(var(--content-primary));
+}
+

--- a/src/verification-center/flow/index.ts
+++ b/src/verification-center/flow/index.ts
@@ -1,0 +1,10 @@
+// Flow diagram components for the verifier
+export { CollapsibleFlowDiagram } from './collapsible-flow-diagram'
+export {
+  default as ContainerNode,
+  type ContainerNodeType,
+} from './container-node'
+export { default as TurboEdge } from './turbo-edge'
+export { default as TurboNode, type TurboNodeData } from './turbo-node'
+export { VerificationFlow } from './verification-flow'
+

--- a/src/verification-center/flow/turbo-edge.tsx
+++ b/src/verification-center/flow/turbo-edge.tsx
@@ -1,0 +1,88 @@
+'use client'
+
+import { getBezierPath, type Edge, type EdgeProps } from '@xyflow/react'
+import { memo } from 'react'
+
+type CustomEdge = Edge
+
+function TurboEdge({
+  id,
+  sourceX,
+  sourceY,
+  targetX,
+  targetY,
+  sourcePosition,
+  targetPosition,
+  style = {},
+  markerEnd,
+  data,
+  sourceHandleId,
+  targetHandleId,
+}: EdgeProps<CustomEdge>) {
+  const xEqual = sourceX === targetX
+  const yEqual = sourceY === targetY
+
+  let adjustedSourceX = sourceX
+  let adjustedSourceY = sourceY
+  let adjustedTargetX = targetX
+  let adjustedTargetY = targetY
+
+  if (id === 'e-enclave-attestation') {
+    adjustedSourceX = sourceX + 100
+  }
+
+  if (id === 'e-client-github') {
+    adjustedSourceX = sourceX
+  }
+
+  if (id === 'e-client-sigstore') {
+    adjustedSourceX = sourceX
+  }
+
+  const pathParams = {
+    sourceX: xEqual ? adjustedSourceX + 0.0001 : adjustedSourceX,
+    sourceY: yEqual ? adjustedSourceY + 0.0001 : adjustedSourceY,
+    sourcePosition,
+    targetX: adjustedTargetX,
+    targetY: adjustedTargetY,
+    targetPosition,
+    curvature: 0.3,
+  }
+
+  if (sourceHandleId === 'source-left') {
+    pathParams.sourceX -= 5
+  } else if (sourceHandleId === 'source-right') {
+    pathParams.sourceX += 5
+  } else if (sourceHandleId === 'source-top') {
+    pathParams.sourceY -= 5
+  } else if (sourceHandleId === 'source-bottom') {
+    pathParams.sourceY += 5
+  }
+
+  if (targetHandleId === 'target-left') {
+    pathParams.targetX -= 5
+  } else if (targetHandleId === 'target-right') {
+    pathParams.targetX += 5
+  } else if (targetHandleId === 'target-top') {
+    pathParams.targetY -= 5
+  } else if (targetHandleId === 'target-bottom') {
+    pathParams.targetY += 5
+  }
+
+  const [edgePath] = getBezierPath(pathParams)
+
+  return (
+    <path
+      id={id}
+      style={{ stroke: 'rgba(0, 0, 0, 0.6)', ...style }}
+      className="react-flow__edge-path"
+      d={edgePath}
+      markerEnd={markerEnd}
+    />
+  )
+}
+
+TurboEdge.displayName = 'TurboEdge'
+
+export default memo(TurboEdge)
+

--- a/src/verification-center/flow/turbo-node.tsx
+++ b/src/verification-center/flow/turbo-node.tsx
@@ -1,0 +1,161 @@
+'use client'
+
+import type { Node, NodeProps } from '@xyflow/react'
+import { Handle, Position } from '@xyflow/react'
+import { memo } from 'react'
+
+type TurboNodeData = {
+  title: string
+  subtitle?: string
+  icon?: React.ReactNode
+  isEnclave?: boolean
+  isContainer?: boolean
+}
+
+type CustomNode = Node<TurboNodeData>
+
+const getNodeStyle = (title: string) => {
+  switch (title) {
+    case 'Tinfoil Server':
+      return {
+        backgroundColor: 'rgba(220,220,220,0.2)',
+        color: 'var(--text-color)',
+        borderRadius: '24px',
+      }
+    case 'Client':
+    case 'Secure Hardware Enclave':
+      return {
+        backgroundColor: 'rgba(193, 225, 255, 0.2)',
+        color: 'var(--text-color)',
+        borderRadius: '24px',
+      }
+    case 'Verification Engine':
+      return {
+        backgroundColor: 'rgba(16, 185, 129, 0.15)',
+        color: 'var(--text-color)',
+        borderRadius: '24px',
+      }
+    case 'You':
+      return {
+        backgroundColor: 'rgba(16, 185, 129, 0.1)',
+        color: 'var(--text-color)',
+        borderRadius: '24px',
+      }
+    default:
+      return {}
+  }
+}
+
+function TurboNode(props: NodeProps<CustomNode>) {
+  const { data, ...rest } = props
+  const style = (rest as any).style || {}
+  const nodeStyle = getNodeStyle(data.title)
+  const iconColor = nodeStyle.color || 'currentColor'
+
+  if (data.isContainer) {
+    return (
+      <div
+        className="container-node"
+        style={{
+          ...style,
+          ...nodeStyle,
+          color: 'var(--text-color)',
+        }}
+      >
+        <div className="container-header">
+          <div className="icon" style={{ color: iconColor }}>
+            {data.icon}
+          </div>
+          <div className="title">{data.title}</div>
+        </div>
+        <Handle type="target" position={Position.Top} id="target-top" className="connection-handle" style={{ left: '50%' }} />
+        <Handle type="source" position={Position.Top} id="source-top" className="connection-handle" style={{ left: '50%' }} />
+        <Handle type="target" position={Position.Left} id="target-left" className="connection-handle" style={{ top: '50%' }} />
+        <Handle type="source" position={Position.Left} id="source-left" className="connection-handle" style={{ top: '50%' }} />
+        <Handle type="target" position={Position.Right} id="target-right" className="connection-handle" style={{ top: '50%' }} />
+        <Handle type="source" position={Position.Right} id="source-right" className="connection-handle" style={{ top: '50%' }} />
+        <Handle type="target" position={Position.Bottom} id="target-bottom" className="connection-handle" style={{ left: '50%' }} />
+        <Handle type="source" position={Position.Bottom} id="source-bottom" className="connection-handle" style={{ left: '50%' }} />
+      </div>
+    )
+  }
+
+  const isColoredNode = !!nodeStyle.backgroundColor
+
+  return isColoredNode ? (
+    <div
+      style={{
+        backgroundColor: nodeStyle.backgroundColor,
+        color: nodeStyle.color || 'var(--text-color)',
+        borderRadius: '24px',
+        padding: '16px 20px',
+        display: 'flex',
+        alignItems: 'center',
+        width: 'auto',
+        minWidth: '150px',
+        height: '70px',
+        fontWeight: 500,
+        letterSpacing: '-0.2px',
+        boxSizing: 'border-box',
+        position: 'relative',
+        border: 'none',
+        boxShadow: 'none',
+      }}
+      className={`colored-node ${data.isEnclave ? 'enclave-node' : ''}`}
+    >
+      <div
+        style={{
+          color: 'currentColor',
+          marginRight: '8px',
+          display: 'flex',
+          opacity: 0.8,
+        }}
+      >
+        {data.icon}
+      </div>
+      <div>
+        <div style={{ fontSize: '16px', marginBottom: '2px' }}>{data.title}</div>
+        {data.subtitle && <div style={{ fontSize: '12px', opacity: 0.7 }}>{data.subtitle}</div>}
+      </div>
+
+      <Handle type="target" position={Position.Left} id="target-left" className="connection-handle" />
+      <Handle type="source" position={Position.Left} id="source-left" className="connection-handle" />
+      <Handle type="target" position={Position.Right} id="target-right" className="connection-handle" />
+      <Handle type="source" position={Position.Right} id="source-right" className="connection-handle" />
+      <Handle type="target" position={Position.Top} id="target-top" className="connection-handle" style={{ left: '50%' }} />
+      <Handle type="source" position={Position.Top} id="source-top" className="connection-handle" style={{ left: '50%' }} />
+      <Handle type="target" position={Position.Bottom} id="target-bottom" className="connection-handle" style={{ left: '50%' }} />
+      <Handle type="source" position={Position.Bottom} id="source-bottom" className="connection-handle" style={{ left: '50%' }} />
+    </div>
+  ) : (
+    <div className={`react-flow__node-turbo ${data.isEnclave ? 'enclave-node' : ''}`}>
+      <div className="wrapper gradient">
+        <div className="inner">
+          <div className="body">
+            <div className="icon" style={{ color: iconColor }}>
+              {data.icon}
+            </div>
+            <div>
+              <div className="title">{data.title}</div>
+              {data.subtitle && <div className="subtitle">{data.subtitle}</div>}
+            </div>
+          </div>
+          <Handle type="target" position={Position.Left} id="target-left" className="connection-handle" />
+          <Handle type="source" position={Position.Left} id="source-left" className="connection-handle" />
+          <Handle type="target" position={Position.Right} id="target-right" className="connection-handle" />
+          <Handle type="source" position={Position.Right} id="source-right" className="connection-handle" />
+          <Handle type="target" position={Position.Top} id="target-top" className="connection-handle" style={{ left: '50%' }} />
+          <Handle type="source" position={Position.Top} id="source-top" className="connection-handle" style={{ left: '50%' }} />
+          <Handle type="target" position={Position.Bottom} id="target-bottom" className="connection-handle" style={{ left: '50%' }} />
+          <Handle type="source" position={Position.Bottom} id="source-bottom" className="connection-handle" style={{ left: '50%' }} />
+        </div>
+      </div>
+    </div>
+  )
+}
+
+TurboNode.displayName = 'TurboNode'
+
+export type { TurboNodeData }
+export default memo(TurboNode)
+

--- a/src/verification-center/flow/verification-flow.tsx
+++ b/src/verification-center/flow/verification-flow.tsx
@@ -1,0 +1,351 @@
+'use client'
+
+import { ShieldCheckIcon } from '@heroicons/react/24/outline'
+import {
+  Background,
+  BackgroundVariant,
+  ReactFlow,
+  ReactFlowProvider,
+  useEdgesState,
+  useNodesState,
+  useReactFlow,
+  type Edge,
+  type Node,
+} from '@xyflow/react'
+import { useEffect, useState } from 'react'
+import { FaUser } from 'react-icons/fa'
+import { FiGithub, FiKey, FiShield } from 'react-icons/fi'
+import { LuBrain, LuCpu } from 'react-icons/lu'
+import ContainerNode, { type ContainerNodeType } from './container-node'
+import TurboEdge from './turbo-edge'
+import TurboNode, { type TurboNodeData } from './turbo-node'
+
+import '@xyflow/react/dist/style.css'
+import './flow.css'
+
+type VerificationFlowProps = {
+  isDarkMode: boolean
+  verificationStatus?: 'idle' | 'verifying' | 'success' | 'error'
+}
+
+type CustomNode = Node<TurboNodeData>
+
+function VerificationFlowDiagram({
+  isDarkMode,
+  verificationStatus = 'idle',
+}: VerificationFlowProps) {
+  const [isReady, setIsReady] = useState(false)
+  const initialNodes: (CustomNode | ContainerNodeType)[] = [
+    {
+      id: 'secure-hardware',
+      position: { x: 77, y: -400 },
+      data: {
+        title: 'Secure Hardware Enclave',
+        icon: <LuCpu className="h-5 w-5" />,
+        containerId: 'secure-hardware-container',
+      },
+      type: 'container',
+      style: {
+        width: 280,
+        height: 220,
+        zIndex: 0,
+      },
+    },
+    {
+      id: 'client',
+      position: { x: 130, y: -20 },
+      data: {
+        title: 'Tinfoil Verifier',
+        icon: <ShieldCheckIcon className="h-5 w-5" />,
+      },
+      type: 'turbo',
+      style: {
+        width: 280,
+      },
+    },
+    {
+      id: 'ai-model',
+      position: { x: 65, y: 50 },
+      data: {
+        title: 'AI Model',
+        icon: <LuBrain />,
+      },
+      type: 'turbo',
+      parentId: 'secure-hardware',
+      extent: 'parent',
+      style: {
+        zIndex: 1,
+      },
+    },
+    {
+      id: 'attestation',
+      position: { x: 20, y: 130 },
+      data: {
+        title: 'Enclave Attestation',
+        subtitle: 'Enclave Runtime Verification',
+        icon: <FiShield />,
+      },
+      type: 'turbo',
+      parentId: 'secure-hardware',
+      extent: 'parent',
+      style: {
+        zIndex: 1,
+      },
+    },
+    {
+      id: 'transparency',
+      position: { x: -40, y: -150 },
+      data: {
+        title: 'Transparency Log',
+        subtitle: 'Artifact Verification',
+        icon: <FiKey />,
+      },
+      type: 'turbo',
+    },
+    {
+      id: 'github',
+      position: { x: 300, y: -150 },
+      data: {
+        title: 'GitHub',
+        subtitle: 'Source Code',
+        icon: <FiGithub />,
+      },
+      type: 'turbo',
+    },
+    {
+      id: 'user',
+      position: { x: 144, y: 100 },
+      data: {
+        title: 'This Chat',
+        icon: <FaUser />,
+      },
+      type: 'turbo',
+      style: {
+        width: 280,
+      },
+    },
+  ]
+
+  const initialEdges: Edge[] = [
+    {
+      id: 'attestation-client',
+      source: 'attestation',
+      target: 'client',
+      type: 'turbo',
+      sourceHandle: 'source-bottom',
+      targetHandle: 'target-top',
+      animated: true,
+      style: {
+        stroke: isDarkMode
+          ? 'rgba(255, 255, 255, 0.4)'
+          : 'rgba(107, 114, 128, 0.5)',
+        strokeDasharray: '5 5',
+        strokeWidth: 1.5,
+      },
+    },
+    {
+      id: 'transparency-client',
+      source: 'transparency',
+      target: 'client',
+      type: 'turbo',
+      sourceHandle: 'source-bottom',
+      targetHandle: 'target-top',
+      animated: true,
+      style: {
+        stroke: isDarkMode
+          ? 'rgba(255, 255, 255, 0.4)'
+          : 'rgba(107, 114, 128, 0.5)',
+        strokeDasharray: '5 5',
+        strokeWidth: 1.5,
+      },
+    },
+    {
+      id: 'github-client',
+      source: 'github',
+      target: 'client',
+      type: 'turbo',
+      sourceHandle: 'source-bottom',
+      targetHandle: 'target-top',
+      animated: true,
+      style: {
+        stroke: isDarkMode
+          ? 'rgba(255, 255, 255, 0.4)'
+          : 'rgba(107, 114, 128, 0.5)',
+        strokeDasharray: '5 5',
+        strokeWidth: 1.5,
+      },
+    },
+    {
+      id: 'client-user',
+      source: 'client',
+      target: 'user',
+      type: 'turbo',
+      sourceHandle: 'source-bottom',
+      targetHandle: 'target-top',
+      animated: true,
+      style: {
+        stroke: isDarkMode
+          ? 'rgba(255, 255, 255, 0.4)'
+          : 'rgba(107, 114, 128, 0.5)',
+        strokeDasharray: '5 5',
+        strokeWidth: 1.5,
+      },
+    },
+  ]
+
+  const [nodes, setNodes, onNodesChange] = useNodesState(initialNodes)
+  const [edges, setEdges, onEdgesChange] = useEdgesState(initialEdges)
+  const reactFlowInstance = useReactFlow()
+
+  useEffect(() => {
+    setEdges((eds) =>
+      eds.map((edge) => ({
+        ...edge,
+        animated: verificationStatus === 'verifying',
+        style: {
+          stroke:
+            verificationStatus === 'success'
+              ? 'rgba(16, 185, 129, 0.6)'
+              : verificationStatus === 'error'
+                ? 'rgba(239, 68, 68, 0.6)'
+                : isDarkMode
+                  ? 'rgba(255, 255, 255, 0.4)'
+                  : 'rgba(107, 114, 128, 0.5)',
+          strokeDasharray: verificationStatus === 'verifying' ? '5 5' : '5 5',
+          strokeWidth: verificationStatus === 'verifying' ? 2 : 1.5,
+        },
+      })),
+    )
+  }, [isDarkMode, verificationStatus, setEdges])
+
+  useEffect(() => {
+    setNodes((nds) =>
+      nds.map((node) => {
+        if (node.id === 'client') {
+          return {
+            ...node,
+            data: {
+              ...node.data,
+              verificationStatus,
+            },
+          }
+        }
+        return node
+      }),
+    )
+  }, [verificationStatus, setNodes])
+
+  const nodeTypes = {
+    turbo: TurboNode,
+    container: ContainerNode,
+  }
+
+  const edgeTypes = {
+    turbo: TurboEdge,
+  }
+
+  const defaultEdgeOptions = {
+    type: 'turbo',
+    markerEnd: 'circle-marker',
+    markerStart: 'circle-marker',
+    animated: true,
+  }
+
+  return (
+    <>
+      <style>{`
+        .verification-flow-container .react-flow__node-turbo {
+          background-color: transparent !important;
+        }
+        .verification-flow-container .react-flow__node {
+          background-color: transparent !important;
+          box-shadow: none !important;
+          border: none !important;
+          padding: 0 !important;
+        }
+      `}</style>
+      <div
+        className={`verification-flow-container h-[280px] w-full ${isDarkMode ? 'dark' : ''}`}
+        style={{
+          fontSize: '120%',
+          opacity: isReady ? 1 : 0,
+          transition: 'opacity 120ms ease',
+        }}
+      >
+        <ReactFlow
+          nodes={nodes}
+          edges={edges}
+          onNodesChange={onNodesChange}
+          onEdgesChange={onEdgesChange}
+          nodeTypes={nodeTypes}
+          edgeTypes={edgeTypes}
+          defaultEdgeOptions={defaultEdgeOptions}
+          fitView={false}
+          onInit={(instance) => {
+            try {
+              instance.fitView({ padding: 0.05 })
+            } finally {
+              requestAnimationFrame(() => setIsReady(true))
+            }
+          }}
+          nodesDraggable={false}
+          nodesConnectable={false}
+          elementsSelectable={false}
+          zoomOnScroll={false}
+          zoomOnPinch={false}
+          panOnDrag={false}
+          preventScrolling={false}
+          proOptions={{ hideAttribution: true }}
+        >
+          <Background
+            variant={BackgroundVariant.Dots}
+            gap={26}
+            size={1.3}
+            color={isDarkMode ? 'hsl(var(--gray-700))' : 'hsl(var(--gray-200))'}
+          />
+
+          <svg width="0" height="0" style={{ position: 'absolute' }}>
+            <defs>
+              <marker
+                id="circle-marker"
+                viewBox="0 0 10 10"
+                refX="5"
+                refY="5"
+                markerWidth="10"
+                markerHeight="10"
+                orient="auto"
+              >
+                <circle cx="5" cy="5" r="3" fill="rgba(80, 100, 120, 0.6)" />
+              </marker>
+            </defs>
+          </svg>
+        </ReactFlow>
+      </div>
+    </>
+  )
+}
+
+function VerificationFlowWrapper(props: VerificationFlowProps) {
+  return (
+    <ReactFlowProvider>
+      <VerificationFlowDiagram {...props} />
+    </ReactFlowProvider>
+  )
+}
+
+export function VerificationFlow({
+  isDarkMode,
+  verificationStatus,
+}: VerificationFlowProps) {
+  return (
+    <div className="px-2 py-0">
+      <div className="overflow-hidden rounded-lg bg-transparent">
+        <VerificationFlowWrapper
+          isDarkMode={isDarkMode}
+          verificationStatus={verificationStatus}
+        />
+      </div>
+    </div>
+  )
+}
+

--- a/src/verification-center/index.tsx
+++ b/src/verification-center/index.tsx
@@ -1,0 +1,3 @@
+export { VerificationCenter as default, VerificationCenter } from './verifier'
+export * from './flow'
+export * from './steps'

--- a/src/verification-center/steps/index.ts
+++ b/src/verification-center/steps/index.ts
@@ -1,0 +1,5 @@
+// Step components for the verification process
+export { MeasurementDiff } from './measurement-diff'
+export { ProcessStep } from './process-step'
+export { StatusIcon } from './status-icon'
+

--- a/src/verification-center/steps/measurement-diff.tsx
+++ b/src/verification-center/steps/measurement-diff.tsx
@@ -1,0 +1,135 @@
+import { CheckIcon, ExclamationTriangleIcon } from '@heroicons/react/24/outline'
+
+interface MeasurementData {
+  measurement?: string
+  certificate?: string
+}
+
+type MeasurementDiffProps = {
+  sourceMeasurements: MeasurementData | string
+  runtimeMeasurements: MeasurementData | string
+  isVerified: boolean
+  isDarkMode?: boolean
+}
+
+const extractMeasurement = (data: MeasurementData | string): string => {
+  if (typeof data === 'string') {
+    try {
+      const parsed = JSON.parse(data)
+      if (parsed.registers && Array.isArray(parsed.registers) && parsed.registers.length > 0) {
+        return String(parsed.registers[0])
+      }
+    } catch {}
+    return data
+  }
+  if (typeof data === 'object' && data?.measurement) {
+    try {
+      const parsed = JSON.parse(data.measurement)
+      if (parsed.registers && Array.isArray(parsed.registers) && parsed.registers.length > 0) {
+        return String(parsed.registers[0])
+      }
+    } catch {}
+    return data.measurement
+  }
+  return JSON.stringify(data, null, 2).replace(/\"/g, '')
+}
+
+export function MeasurementDiff({
+  sourceMeasurements,
+  runtimeMeasurements,
+  isVerified,
+  isDarkMode = true,
+}: MeasurementDiffProps) {
+  return (
+    <div>
+      <div
+        className={`mb-4 flex items-center gap-2 rounded-lg p-3 transition-colors ${
+          isVerified
+            ? isDarkMode
+              ? 'bg-emerald-500/10 text-emerald-400'
+              : 'bg-emerald-50 text-emerald-600'
+            : isDarkMode
+              ? 'bg-red-500/10 text-red-400'
+              : 'bg-red-50 text-red-600'
+        }`}
+      >
+        {isVerified ? (
+          <CheckIcon className="h-5 w-5" />
+        ) : (
+          <ExclamationTriangleIcon className="h-5 w-5" />
+        )}
+        <span className="text-sm">
+          {isVerified ? 'Measurements Match' : 'Measurement mismatch detected'}
+        </span>
+      </div>
+
+      <div className="space-y-4">
+        <div>
+          <h4
+            className={`mb-2 text-sm font-medium ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}
+          >
+            Source Measurement
+            <span
+              className={`block text-xs font-normal ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}
+            >
+              Received from GitHub and Sigstore.
+            </span>
+          </h4>
+          <div className="max-h-[200px] overflow-auto">
+            <pre
+              className={`overflow-x-auto whitespace-pre-wrap break-all rounded-lg transition-colors ${
+                isDarkMode ? 'bg-gray-700 text-gray-100' : 'bg-gray-50 text-gray-900'
+              } border p-3 text-sm ${
+                isVerified ? 'border-emerald-500/50' : isDarkMode ? 'border-gray-700' : 'border-gray-300'
+              }`}
+            >
+              {extractMeasurement(sourceMeasurements)}
+            </pre>
+          </div>
+        </div>
+
+        <div>
+          <h4
+            className={`mb-2 text-sm font-medium ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}
+          >
+            Runtime Measurement
+            <span
+              className={`block text-xs font-normal ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}
+            >
+              Received from the enclave.
+            </span>
+          </h4>
+          <div className="max-h-[200px] overflow-auto">
+            <pre
+              className={`overflow-x-auto whitespace-pre-wrap break-all rounded-lg transition-colors ${
+                isDarkMode ? 'bg-gray-700 text-gray-100' : 'bg-gray-50 text-gray-900'
+              } border p-3 text-sm ${
+                isVerified ? 'border-emerald-500/50' : isDarkMode ? 'border-gray-700' : 'border-gray-300'
+              }`}
+            >
+              {extractMeasurement(runtimeMeasurements)}
+            </pre>
+          </div>
+        </div>
+
+        {!isVerified && (
+          <div
+            className={`flex items-start gap-2 rounded-lg ${
+              isDarkMode ? 'bg-yellow-500/10' : 'bg-yellow-50'
+            } p-3 ${isDarkMode ? 'text-yellow-400' : 'text-yellow-700'}`}
+          >
+            <ExclamationTriangleIcon className="mt-0.5 h-5 w-5 flex-shrink-0" />
+            <div>
+              <p className="break-normal text-sm font-medium">Differences detected:</p>
+              <p className="mt-1 break-normal text-sm">
+                Please check the hash above for discrepancies. This indicates a
+                potential security issue.
+              </p>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+

--- a/src/verification-center/steps/process-step.tsx
+++ b/src/verification-center/steps/process-step.tsx
@@ -1,0 +1,292 @@
+import {
+  ChevronDownIcon,
+  ExclamationTriangleIcon,
+} from '@heroicons/react/24/outline'
+import { AnimatePresence, motion } from 'framer-motion'
+import { useEffect, useState } from 'react'
+import { IoCodeSlashOutline } from 'react-icons/io5'
+import { StatusIcon } from './status-icon'
+import type { VerificationDocument } from '../../verifier'
+
+type DigestType = 'SOURCE' | 'RUNTIME' | 'CODE_INTEGRITY' | 'GENERIC'
+
+interface MeasurementData {
+  measurement?: string
+  certificate?: string
+}
+
+const extractMeasurement = (data: MeasurementData | string): string => {
+  if (typeof data === 'string') {
+    try {
+      const parsed = JSON.parse(data.replace(/^\"|\"$/g, ''))
+      if (parsed.registers && Array.isArray(parsed.registers) && parsed.registers.length > 0) {
+        return parsed.registers[0]
+      }
+    } catch {}
+    return data.replace(/^\"|\"$/g, '')
+  }
+  if (typeof data === 'object' && data?.measurement) {
+    try {
+      const parsed = JSON.parse(data.measurement)
+      if (parsed.registers && Array.isArray(parsed.registers) && parsed.registers.length > 0) {
+        return parsed.registers[0]
+      }
+    } catch {}
+    return data.measurement
+  }
+  return JSON.stringify(data, null, 2)
+}
+
+function getMeasurementLabel(digestType?: DigestType): {
+  title: string
+  subtitle?: string
+} {
+  switch (digestType) {
+    case 'SOURCE':
+      return {
+        title: 'Source Measurement',
+        subtitle: 'Received from GitHub and Sigstore.',
+      }
+    case 'RUNTIME':
+      return {
+        title: 'Runtime Measurement',
+        subtitle: 'Received from the enclave.',
+      }
+    case 'CODE_INTEGRITY':
+      return {
+        title: 'Security Verification',
+        subtitle: 'Comparison of source and runtime measurements.',
+      }
+    default:
+      return { title: 'Measurement' }
+  }
+}
+
+const contentVariants = {
+  hidden: { opacity: 0 },
+  visible: { opacity: 1, transition: { delayChildren: 0.05, staggerChildren: 0.06 } },
+} as const
+
+const itemVariants = {
+  hidden: { opacity: 0, y: 8 },
+  visible: { opacity: 1, y: 0, transition: { duration: 0.2, ease: 'easeOut' } },
+} as const
+
+type ProcessStepProps = {
+  title: string
+  description: string
+  status: 'pending' | 'loading' | 'success' | 'error'
+  error?: string
+  measurements?: MeasurementData | string
+  technicalDetails?: string
+  children?: React.ReactNode
+  digestType?: DigestType
+  githubHash?: string
+  verificationDocument?: VerificationDocument
+  isDarkMode?: boolean
+}
+
+export function ProcessStep({
+  title,
+  description,
+  status,
+  error,
+  measurements,
+  technicalDetails,
+  children,
+  digestType,
+  githubHash,
+  verificationDocument,
+  isDarkMode = true,
+}: ProcessStepProps) {
+  const [isOpen, setIsOpen] = useState(status === 'error' || error !== undefined)
+
+  useEffect(() => {
+    if (status === 'error' || error !== undefined) {
+      setIsOpen(true)
+    }
+  }, [status, error])
+
+  const isRemoteAttestation = digestType === 'RUNTIME'
+  const isSourceCodeVerified = digestType === 'SOURCE'
+
+  const label = getMeasurementLabel(digestType)
+
+  const repoForLink = verificationDocument?.configRepo
+  const hashForSigstore = verificationDocument?.releaseDigest ?? githubHash
+
+  return (
+    <div
+      className={`w-full rounded-lg border transition-colors @container ${
+        isDarkMode ? 'border-gray-700' : 'border-gray-200 bg-white'
+      }`}
+    >
+      <button onClick={() => setIsOpen(!isOpen)} className="w-full px-4 pb-2.5 pt-3.5 text-left">
+        <div className="flex flex-row items-center gap-3 md:gap-4">
+          <div className="flex items-center">
+            <StatusIcon status={status} />
+          </div>
+
+          <div className="flex-1 text-center @[400px]:text-left">
+            <h3 className={`text-sm font-medium ${isDarkMode ? 'text-gray-100' : 'text-gray-900'}`}>{title}</h3>
+            <p className={`hidden text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-600'} @[400px]:block`}>
+              {description}
+            </p>
+          </div>
+
+          <motion.div
+            animate={{ rotate: isOpen ? 180 : 0 }}
+            transition={{ duration: 0.2, ease: 'easeOut' }}
+            className={`rounded-lg p-2 ${isDarkMode ? 'hover:bg-gray-800' : 'hover:bg-gray-100'}`}
+          >
+            <ChevronDownIcon className={`h-5 w-5 ${isDarkMode ? 'text-gray-400' : 'text-gray-500'}`} />
+          </motion.div>
+        </div>
+      </button>
+
+      <AnimatePresence initial={false}>
+        {isOpen ? (
+          <motion.div
+            key="process-step-content"
+            initial={{ height: 0, opacity: 0 }}
+            animate={{ height: 'auto', opacity: 1 }}
+            exit={{ height: 0, opacity: 0 }}
+            transition={{ height: { duration: 0.3, ease: [0.25, 0.8, 0.25, 1] }, opacity: { duration: 0.2, ease: 'easeOut' } }}
+            className="overflow-hidden"
+          >
+            <motion.div className="space-y-4 px-4 pb-4" variants={contentVariants} initial="hidden" animate="visible" exit="hidden">
+              <motion.p variants={itemVariants} className={`block text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-600'} @[400px]:hidden`}>
+                {description}
+              </motion.p>
+
+              {error && status === 'error' && (
+                <motion.div
+                  variants={itemVariants}
+                  className={`flex items-start gap-2 rounded-lg transition-colors ${
+                    isDarkMode ? 'bg-red-500/10' : 'bg-red-50'
+                  } p-3 ${isDarkMode ? 'text-red-400' : 'text-red-600'}`}
+                >
+                  <ExclamationTriangleIcon className="mt-0.5 h-5 w-5 flex-shrink-0" />
+                  <p className="overflow-hidden break-words text-sm">{error}</p>
+                </motion.div>
+              )}
+
+              {measurements && (
+                <motion.div variants={itemVariants}>
+                  <div className="mb-2 flex items-start justify-between">
+                    <h4 className={`text-sm font-medium ${isDarkMode ? 'text-gray-100' : 'text-gray-800'}`}>
+                      {label.title}
+                      {label.subtitle && (
+                        <span className={`block text-xs font-normal ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}>
+                          {label.subtitle}
+                        </span>
+                      )}
+                    </h4>
+                    <div className="flex items-center gap-2">
+                      {digestType === 'SOURCE' ? (
+                        <IoCodeSlashOutline className={`${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`} size={20} />
+                      ) : digestType === 'RUNTIME' ? (
+                        <span className={`${isDarkMode ? 'text-gray-400' : 'text-gray-600'} text-xs`}>CPU + GPU</span>
+                      ) : null}
+                    </div>
+                  </div>
+                  <pre
+                    className={`overflow-x-auto whitespace-pre-wrap break-all rounded-lg transition-colors ${
+                      isDarkMode ? 'bg-gray-700 text-gray-100' : 'bg-gray-50 text-gray-900'
+                    } border p-4 text-sm ${
+                      status === 'success' ? 'border-emerald-500/50' : isDarkMode ? 'border-gray-700' : 'border-gray-300'
+                    }`}
+                  >
+                    {extractMeasurement(measurements)}
+                  </pre>
+                </motion.div>
+              )}
+
+              {isRemoteAttestation && (
+                <motion.div variants={itemVariants} className="mt-3">
+                  <h4 className={`mb-2 text-sm font-medium ${isDarkMode ? 'text-gray-100' : 'text-gray-800'}`}>Runtime attested by</h4>
+                  <div className={`mt-2 flex items-center space-x-2 ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}>
+                    <a
+                      href="https://docs.nvidia.com/attestation/index.html"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className={`inline-flex items-center gap-1 rounded-lg p-2 text-xs ${
+                        isDarkMode ? 'bg-gray-700 hover:bg-gray-600' : 'bg-gray-50 hover:bg-gray-200'
+                      }`}
+                    >
+                      NVIDIA
+                    </a>
+                    <a
+                      href="https://www.amd.com/en/developer/sev.html"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className={`inline-flex items-center gap-1 rounded-lg p-2 text-xs ${
+                        isDarkMode ? 'bg-gray-700 hover:bg-gray-600' : 'bg-gray-50 hover:bg-gray-200'
+                      }`}
+                    >
+                      AMD
+                    </a>
+                    <a
+                      href="https://www.intel.com/content/www/us/en/developer/tools/trust-domain-extensions/overview.html"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className={`inline-flex items-center gap-1 rounded-lg p-2 text-xs ${
+                        isDarkMode ? 'bg-gray-700 hover:bg-gray-600' : 'bg-gray-50 hover:bg-gray-200'
+                      }`}
+                    >
+                      Intel
+                    </a>
+                  </div>
+                </motion.div>
+              )}
+
+              {isSourceCodeVerified && (
+                <motion.div variants={itemVariants} className="mt-3">
+                  <h4 className={`mb-2 text-sm font-medium ${isDarkMode ? 'text-gray-100' : 'text-gray-800'}`}>
+                    Code integrity attested by
+                  </h4>
+                  <div className="mt-2 flex items-center space-x-4">
+                    {repoForLink && (
+                      <a
+                        href={`https://github.com/${repoForLink}`}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className={`inline-flex items-center gap-1.5 text-sm ${
+                          isDarkMode ? 'text-gray-300 hover:text-gray-100' : 'text-gray-700 hover:text-gray-900'
+                        }`}
+                      >
+                        <span>GitHub</span>
+                      </a>
+                    )}
+                    {hashForSigstore && (
+                      <a
+                        href={`https://search.sigstore.dev/?hash=${hashForSigstore}`}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className={`inline-flex items-center gap-1.5 text-sm ${
+                          isDarkMode ? 'text-gray-300 hover:text-gray-100' : 'text-gray-700 hover:text-gray-900'
+                        }`}
+                      >
+                        <span>Sigstore</span>
+                      </a>
+                    )}
+                  </div>
+                </motion.div>
+              )}
+
+              {children && <motion.div variants={itemVariants}>{children}</motion.div>}
+
+              {technicalDetails && (
+                <motion.div variants={itemVariants}>
+                  <h4 className={`mb-2 text-sm font-medium ${isDarkMode ? 'text-gray-100' : 'text-gray-800'}`}>Technical Details</h4>
+                  <p className={`text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}>{technicalDetails}</p>
+                </motion.div>
+              )}
+            </motion.div>
+          </motion.div>
+        ) : null}
+      </AnimatePresence>
+    </div>
+  )
+}
+

--- a/src/verification-center/steps/status-icon.tsx
+++ b/src/verification-center/steps/status-icon.tsx
@@ -1,0 +1,39 @@
+import { CheckIcon, XMarkIcon } from '@heroicons/react/24/outline'
+
+type StatusIconProps = {
+  status: 'pending' | 'loading' | 'success' | 'error'
+}
+
+export function StatusIcon({ status }: StatusIconProps) {
+  const iconMap = {
+    success: {
+      bg: 'bg-emerald-500',
+      icon: <CheckIcon className="h-[8.8px] w-[8.8px] text-white" />,
+    },
+    error: {
+      bg: 'bg-red-500',
+      icon: <XMarkIcon className="h-[8.8px] w-[8.8px] text-white" />,
+    },
+    loading: {
+      bg: 'bg-blue-500',
+      icon: (
+        <div className="h-[8.8px] w-[8.8px] animate-spin rounded-full border border-white border-t-transparent" />
+      ),
+    },
+    pending: {
+      bg: 'bg-gray-500',
+      icon: null,
+    },
+  }
+
+  const { bg, icon } = iconMap[status]
+
+  return (
+    <div
+      className={`flex h-[17.6px] w-[17.6px] items-center justify-center rounded-full transition-colors duration-300 ${bg}`}
+    >
+      {icon}
+    </div>
+  )
+}
+

--- a/src/verification-center/types.d.ts
+++ b/src/verification-center/types.d.ts
@@ -1,0 +1,2 @@
+declare module '*.css'
+

--- a/src/verification-center/verification-status.tsx
+++ b/src/verification-center/verification-status.tsx
@@ -1,0 +1,88 @@
+import { ExclamationTriangleIcon } from '@heroicons/react/24/outline'
+
+type VerificationState = {
+  [key: string]: {
+    status: string
+    error?: string
+  }
+}
+
+type VerificationStatusProps = {
+  verificationState: VerificationState
+  isDarkMode?: boolean
+}
+
+function VerificationStatus({
+  verificationState,
+  isDarkMode = true,
+}: VerificationStatusProps) {
+  const hasErrors = Object.values(verificationState).some(
+    (state) => state.error,
+  )
+  const allSuccess = Object.values(verificationState).every(
+    (state) => state.status === 'success',
+  )
+
+  const status: 'error' | 'success' | 'progress' = hasErrors
+    ? 'error'
+    : allSuccess
+      ? 'success'
+      : 'progress'
+
+  const containerColors =
+    status === 'error'
+      ? isDarkMode
+        ? 'bg-red-500/10 text-red-400'
+        : 'bg-red-50 text-red-600'
+      : status === 'success'
+        ? isDarkMode
+          ? 'bg-emerald-500/10 text-emerald-400'
+          : 'bg-emerald-50 text-emerald-600'
+        : isDarkMode
+          ? 'bg-blue-500/10 text-blue-400'
+          : 'bg-blue-50 text-blue-600'
+
+  return (
+    <div
+      className={`mt-0 flex min-h-16 items-start gap-2 p-3 transition-colors duration-300 ${containerColors}`}
+    >
+      {status === 'error' && (
+        <>
+          <ExclamationTriangleIcon className="mt-0.5 h-5 w-5 flex-shrink-0" />
+          <p className="overflow-hidden break-words break-all text-sm">
+            Verification failed. Please check the errors.
+          </p>
+        </>
+      )}
+
+      {status === 'success' && (
+        <div className="flex flex-col gap-1">
+          <p className="text-sm">This AI is running inside a secure enclave.</p>
+          <div
+            className={`flex items-center gap-2 opacity-70 ${
+              isDarkMode ? 'text-white' : 'text-gray-700'
+            }`}
+          >
+            <span className="text-xs">Attested by</span>
+            <span className="text-xs">NVIDIA</span>
+            <span className="text-sm">·</span>
+            <span className="text-xs">AMD</span>
+            <span className="text-sm">·</span>
+            <span className="text-xs">Intel</span>
+          </div>
+        </div>
+      )}
+
+      {status === 'progress' && (
+        <p className="break-words text-sm">
+          Verification in progress. This process ensures your data remains
+          secure and private by confirming code integrity and runtime
+          environment isolation.
+        </p>
+      )}
+    </div>
+  )
+}
+
+export default VerificationStatus
+

--- a/src/verification-center/verifier.tsx
+++ b/src/verification-center/verifier.tsx
@@ -1,0 +1,452 @@
+'use client'
+
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { AiOutlineLoading3Quarters } from 'react-icons/ai'
+import { FaGithub } from 'react-icons/fa'
+import { LuExternalLink, LuRefreshCcwDot } from 'react-icons/lu'
+import {
+  clearVerificationCache,
+  loadVerifier,
+  type VerificationState as RunnerState,
+} from '../verification-runner'
+import type { VerificationDocument } from '../verifier'
+import { isRealBrowser } from '../env'
+import { CollapsibleFlowDiagram, VerificationFlow } from './flow'
+import { MeasurementDiff, ProcessStep } from './steps'
+import VerificationStatus from './verification-status'
+
+type VerifierProps = {
+  isDarkMode?: boolean
+  flowDiagramExpanded?: boolean
+  onFlowDiagramToggle?: () => void
+  showVerificationFlow?: boolean
+  verificationDocument?: VerificationDocument
+}
+
+type VerificationStatusType = 'error' | 'pending' | 'loading' | 'success'
+
+interface MeasurementData {
+  measurement?: string
+  certificate?: string
+}
+
+type VerificationState = {
+  code: {
+    status: VerificationStatusType
+    measurements?: MeasurementData
+    error?: string
+  }
+  runtime: {
+    status: VerificationStatusType
+    measurements?: MeasurementData
+    error?: string
+  }
+  security: {
+    status: VerificationStatusType
+    error?: string
+  }
+}
+
+type VerificationStepKey =
+  | 'CODE_INTEGRITY'
+  | 'REMOTE_ATTESTATION'
+  | 'CODE_CONSISTENCY'
+
+const VERIFICATION_STEPS = {
+  REMOTE_ATTESTATION: {
+    base: 'Enclave Attestation Verification',
+    loading: 'Fetching Enclave Attestation...',
+    success: 'Enclave Attestation Verified',
+    key: 'REMOTE_ATTESTATION' as VerificationStepKey,
+  },
+  CODE_INTEGRITY: {
+    base: 'Source Code Verification',
+    loading: 'Fetching Source Code...',
+    success: 'Source Code Verified',
+    key: 'CODE_INTEGRITY' as VerificationStepKey,
+  },
+  CODE_CONSISTENCY: {
+    base: 'Security Verification',
+    loading: 'Checking Measurements...',
+    success: 'Security Verified',
+    key: 'CODE_CONSISTENCY' as VerificationStepKey,
+  },
+} as const
+
+const getStepTitle = (
+  stepKey: VerificationStepKey,
+  status: VerificationStatusType,
+) => {
+  const step = VERIFICATION_STEPS[stepKey]
+
+  switch (status) {
+    case 'loading':
+      return step.loading
+    case 'success':
+      return step.success
+    default:
+      return step.base
+  }
+}
+
+function mapRunnerStateToUiState(s: RunnerState): VerificationState {
+  const securityStatus =
+    s.verification.status === 'success'
+      ? s.verification.securityVerified
+        ? 'success'
+        : 'error'
+      : (s.verification.status as VerificationStatusType)
+
+  return {
+    code: {
+      status: s.code.status as VerificationStatusType,
+      measurements: s.code.measurement
+        ? { measurement: JSON.stringify(s.code.measurement) }
+        : undefined,
+      error: s.code.status === 'error' ? s.code.error : undefined,
+    },
+    runtime: {
+      status: s.runtime.status as VerificationStatusType,
+      measurements: s.runtime.measurement
+        ? {
+            measurement: JSON.stringify(s.runtime.measurement),
+            certificate: s.runtime.tlsPublicKeyFingerprint,
+          }
+        : undefined,
+      error: s.runtime.status === 'error' ? s.runtime.error : undefined,
+    },
+    security: {
+      status: securityStatus as VerificationStatusType,
+      error:
+        s.verification.status === 'error'
+          ? s.verification.error
+          : !s.verification.securityVerified &&
+              s.verification.status === 'success'
+            ? 'Code and runtime measurements do not match.'
+            : undefined,
+    },
+  }
+}
+
+export function VerificationCenter({
+  isDarkMode = true,
+  flowDiagramExpanded,
+  onFlowDiagramToggle,
+  showVerificationFlow = true,
+  verificationDocument,
+}: VerifierProps) {
+  if (!isRealBrowser()) {
+    throw new Error(
+      'VerificationCenter is browser-only (React + DOM). Use headless verification helpers in Node: loadVerifier(), Verifier, or TinfoilAI.getVerificationDocument().',
+    )
+  }
+
+  const [optimisticVerifying, setOptimisticVerifying] = useState(true)
+  const [isSafari, setIsSafari] = useState(false)
+  const [digest, setDigest] = useState<string | null>(null)
+
+  const [verificationState, setVerificationState] = useState<VerificationState>(
+    {
+      code: {
+        status: 'pending' as VerificationStatusType,
+        measurements: undefined,
+        error: undefined,
+      },
+      runtime: {
+        status: 'pending' as VerificationStatusType,
+        measurements: undefined,
+        error: undefined,
+      },
+      security: {
+        status: 'pending' as VerificationStatusType,
+        error: undefined,
+      },
+    },
+  )
+
+  const flowStatus = useMemo<'idle' | 'verifying' | 'success' | 'error'>(() => {
+    const isAnyLoading =
+      verificationState.code.status === 'loading' ||
+      verificationState.runtime.status === 'loading' ||
+      verificationState.security.status === 'loading'
+
+    const isAnyError =
+      verificationState.code.status === 'error' ||
+      verificationState.runtime.status === 'error' ||
+      verificationState.security.status === 'error'
+
+    const isAllSuccess =
+      verificationState.code.status === 'success' &&
+      verificationState.runtime.status === 'success' &&
+      verificationState.security.status === 'success'
+
+    if (isAnyLoading) return 'verifying'
+    if (isAllSuccess) return 'success'
+    if (isAnyError) return 'error'
+    return 'idle'
+  }, [verificationState])
+
+  const isCurrentlyVerifying = useMemo(
+    () => optimisticVerifying || flowStatus === 'verifying',
+    [optimisticVerifying, flowStatus],
+  )
+
+  const verifyAll = useCallback(async (forceRefresh = false) => {
+    setOptimisticVerifying(true)
+
+    if (forceRefresh) {
+      clearVerificationCache()
+    }
+
+    const v = await loadVerifier()
+    let hasReceivedUpdate = false
+
+    try {
+      await v.runVerification({
+        onUpdate: (s: RunnerState) => {
+          hasReceivedUpdate = true
+          setDigest(s.releaseDigest || null)
+          const uiState = mapRunnerStateToUiState(s)
+          setVerificationState(uiState)
+        },
+      })
+
+      if (!hasReceivedUpdate) {
+        clearVerificationCache()
+        await v.runVerification({
+          onUpdate: (s: RunnerState) => {
+            setDigest(s.releaseDigest || null)
+            const uiState = mapRunnerStateToUiState(s)
+            setVerificationState(uiState)
+          },
+        })
+      }
+    } finally {
+      setOptimisticVerifying(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    if (verificationDocument) {
+      setOptimisticVerifying(false)
+      setDigest(verificationDocument.releaseDigest || null)
+
+      const uiState: VerificationState = {
+        code: {
+          status: 'success',
+          measurements: verificationDocument.codeMeasurement
+            ? {
+                measurement: JSON.stringify(
+                  verificationDocument.codeMeasurement,
+                ),
+              }
+            : undefined,
+          error: undefined,
+        },
+        runtime: {
+          status: 'success',
+          measurements: verificationDocument.enclaveMeasurement?.measurement
+            ? {
+                measurement: JSON.stringify(
+                  verificationDocument.enclaveMeasurement.measurement,
+                ),
+                certificate:
+                  verificationDocument.enclaveMeasurement
+                    .tlsPublicKeyFingerprint,
+              }
+            : undefined,
+          error: undefined,
+        },
+        security: {
+          status: verificationDocument.match ? 'success' : 'error',
+          error: verificationDocument.match
+            ? undefined
+            : 'Code and runtime measurements do not match.',
+        },
+      }
+      setVerificationState(uiState)
+      return
+    }
+
+    void verifyAll()
+  }, [verifyAll, verificationDocument])
+
+  useEffect(() => {
+    const isSafariCheck = () => {
+      const ua = navigator.userAgent.toLowerCase()
+      const isSafariMobile = ua.includes('safari') && ua.includes('mobile')
+      const isIOS = /iphone|ipad|ipod/.test(ua)
+      return (isSafariMobile || isIOS) && !ua.includes('chrome')
+    }
+
+    setIsSafari(isSafariCheck())
+  }, [])
+
+  return (
+    <div
+      className={`flex h-full w-full flex-col ${isDarkMode ? 'bg-gray-900' : 'bg-white'}`}
+      style={{ fontFamily: 'inherit' }}
+    >
+      <div className="flex-none">
+        <VerificationStatus
+          verificationState={verificationState}
+          isDarkMode={isDarkMode}
+        />
+      </div>
+
+      <div
+        className={`relative w-full flex-1 overflow-y-auto ${isDarkMode ? 'bg-gray-900' : 'bg-white'}`}
+        style={{
+          scrollbarGutter: 'stable',
+          overscrollBehavior: 'contain',
+          WebkitOverflowScrolling: 'touch',
+        }}
+      >
+        <div
+          className={`px-3 py-3 sm:px-4 sm:py-4 ${isDarkMode ? 'bg-gray-900' : 'bg-white'}`}
+        >
+          <div className="mb-3">
+            <h3
+              className={`text-sm font-medium ${isDarkMode ? 'text-gray-100' : 'text-gray-900'}`}
+              style={{ fontFamily: 'inherit' }}
+            >
+              Secure Enclave Verifier
+            </h3>
+          </div>
+
+          <p
+            className={`text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}
+          >
+            This automated verification tool lets you independently confirm that
+            the models are running in secure enclaves, ensuring your
+            conversations remain completely private{' '}
+            <a
+              href="https://docs.tinfoil.sh/verification/attestation-architecture"
+              target="_blank"
+              rel="noopener noreferrer"
+              className={`inline-flex items-center gap-1 hover:underline ${
+                isDarkMode
+                  ? 'text-accent hover:text-accent/80'
+                  : 'text-emerald-600 hover:text-emerald-700'
+              }`}
+            >
+              Attestation architecture
+              <LuExternalLink className="h-3.5 w-3.5" />
+            </a>
+          </p>
+
+          <div className="my-6">
+            <div className="flex items-start gap-3">
+              <button
+                onClick={() => {
+                  if (!isCurrentlyVerifying) {
+                    void verifyAll(true)
+                  }
+                }}
+                disabled={isCurrentlyVerifying}
+                className={`flex items-center justify-center gap-2 whitespace-nowrap rounded-md border px-4 py-2 text-sm font-medium transition-colors ${
+                  isDarkMode
+                    ? 'border-border-strong bg-surface-chat text-content-primary hover:bg-surface-chat/80 disabled:cursor-not-allowed disabled:text-content-muted disabled:hover:bg-surface-chat'
+                    : 'border-gray-300 bg-white text-gray-700 hover:bg-gray-50 disabled:cursor-not-allowed disabled:text-gray-400 disabled:hover:bg-white'
+                }`}
+                style={{ minWidth: '140px', maxWidth: '180px' }}
+              >
+                {isCurrentlyVerifying ? (
+                  <AiOutlineLoading3Quarters className="h-4 w-4 animate-spin" />
+                ) : (
+                  <LuRefreshCcwDot className="h-4 w-4" />
+                )}
+                {isCurrentlyVerifying ? 'Verifying...' : 'Verify Again'}
+              </button>
+
+              <button
+                onClick={() =>
+                  window.open(
+                    'https://github.com/tinfoilsh/verifier/',
+                    '_blank',
+                    'noopener,noreferrer',
+                  )
+                }
+                className={`flex items-center justify-center gap-2 whitespace-nowrap rounded-md border px-4 py-2 text-sm font-medium transition-colors ${
+                  isDarkMode
+                    ? 'border-border-strong bg-surface-chat text-content-primary hover:bg-surface-chat/80'
+                    : 'border-gray-300 bg-white text-gray-700 hover:bg-gray-50'
+                }`}
+                style={{ minWidth: '120px', maxWidth: '160px' }}
+              >
+                <FaGithub className="h-4 w-4" />
+                View Code
+              </button>
+            </div>
+          </div>
+        </div>
+
+        <div className="space-y-3 px-3 pb-6 sm:space-y-4 sm:px-4">
+          {showVerificationFlow && (
+            <CollapsibleFlowDiagram
+              isDarkMode={isDarkMode}
+              isExpanded={flowDiagramExpanded}
+              onToggle={onFlowDiagramToggle}
+            >
+              <VerificationFlow
+                isDarkMode={isDarkMode}
+                verificationStatus={flowStatus}
+              />
+            </CollapsibleFlowDiagram>
+          )}
+
+          <ProcessStep
+            title={getStepTitle(
+              'REMOTE_ATTESTATION',
+              verificationState.runtime.status,
+            )}
+            description="Verifies the secure hardware environment. The response consists of a signed measurement by a combination of NVIDIA, AMD, and Intel certifying the enclave environment and the digest of the binary (i.e., code) actively running inside it."
+            status={verificationState.runtime.status}
+            error={verificationState.runtime.error}
+            measurements={verificationState.runtime.measurements}
+            digestType="RUNTIME"
+            isDarkMode={isDarkMode}
+          />
+
+          <ProcessStep
+            title={getStepTitle(
+              'CODE_INTEGRITY',
+              verificationState.code.status,
+            )}
+            description="Verifies that the source code published publicly by Tinfoil on GitHub was correctly built through GitHub Actions and that the resulting binary is available on the Sigstore transparency log."
+            status={verificationState.code.status}
+            error={verificationState.code.error}
+            measurements={verificationState.code.measurements}
+            digestType="SOURCE"
+            verificationDocument={verificationDocument}
+            githubHash={digest || undefined}
+            isDarkMode={isDarkMode}
+          />
+
+          <ProcessStep
+            title={getStepTitle(
+              'CODE_CONSISTENCY',
+              verificationState.security.status,
+            )}
+            description="Verifies that the binary built from the source code matches the binary running in the secure enclave by comparing digests from the enclave and the committed digest from the transparency log."
+            status={verificationState.security.status}
+            error={verificationState.security.error}
+            digestType="CODE_INTEGRITY"
+            isDarkMode={isDarkMode}
+          >
+            {verificationState.code.measurements &&
+              verificationState.runtime.measurements && (
+                <MeasurementDiff
+                  sourceMeasurements={verificationState.code.measurements}
+                  runtimeMeasurements={verificationState.runtime.measurements}
+                  isVerified={verificationState.security.status === 'success'}
+                  isDarkMode={isDarkMode}
+                />
+              )}
+          </ProcessStep>
+        </div>
+        {isSafari && <div className="h-[30px]" aria-hidden="true" />}
+      </div>
+    </div>
+  )
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
     "target": "ES2020",
     "module": "commonjs",
     "lib": ["es2020", "dom"],
+    "jsx": "react-jsx",
     "declaration": true,
     "outDir": "./dist",
     "rootDir": "./src",


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Adds a React-based Verification Center UI with a flow diagram and step-by-step status for enclave and code verification. Introduces new package subpaths and build updates to ship types, ESM/CJS, and CSS.

- **New Features**
  - VerificationCenter UI with status banner, refresh action, and optional flow diagram.
  - Flow diagram built on @xyflow/react with custom nodes/edges, dark mode, and collapsible container.
  - Step components: ProcessStep, MeasurementDiff, StatusIcon, plus ambient typings to compile without UI deps at build time.

- **Dependencies**
  - New peerDependencies: react, react-dom, @xyflow/react, @heroicons/react, react-icons, framer-motion.
  - Subpath exports: ./react and ./verification-center with types and ESM/CJS entries; browser field points to ESM.
  - Build scripts copy React CSS into dist; sideEffects includes "*.css"; tsconfig set to react-jsx.
  - Import via: import { VerificationCenter } from '<package>/react' or '<package>/verification-center'.

<!-- End of auto-generated description by cubic. -->

