### PR TITLE
feat: browser comapt with fallback

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,14 +6,43 @@
   "module": "dist/esm/index.js",
   "types": "dist/index.d.ts",
   "browser": {
-    "./dist/index.js": "./dist/esm/index.js"
+    "./dist/index.js": "./dist/esm/index.browser.js",
+    "./dist/esm/index.js": "./dist/esm/index.browser.js"
   },
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "require": "./dist/index.js",
+      "browser": "./dist/esm/index.browser.js",
       "import": "./dist/esm/index.js",
+      "require": "./dist/index.js",
       "default": "./dist/index.js"
+    },
+    "./client": {
+      "types": "./dist/client.d.ts",
+      "browser": "./dist/esm/client.browser.js",
+      "import": "./dist/esm/client.js",
+      "require": "./dist/client.js"
+    },
+    "./ai-sdk-provider": {
+      "types": "./dist/ai-sdk-provider.d.ts",
+      "browser": "./dist/esm/ai-sdk-provider.browser.js",
+      "import": "./dist/esm/ai-sdk-provider.js",
+      "require": "./dist/ai-sdk-provider.js"
+    },
+    "./verifier": {
+      "types": "./dist/verifier.d.ts",
+      "import": "./dist/esm/verifier.js",
+      "require": "./dist/verifier.js"
+    },
+    "./verification-runner": {
+      "types": "./dist/verification-runner.d.ts",
+      "import": "./dist/esm/verification-runner.js",
+      "require": "./dist/verification-runner.js"
+    },
+    "./config": {
+      "types": "./dist/config.d.ts",
+      "import": "./dist/esm/config.js",
+      "require": "./dist/config.js"
     }
   },
   "scripts": {

--- a/src/__tests__/client.transport.test.ts
+++ b/src/__tests__/client.transport.test.ts
@@ -4,12 +4,14 @@ import assert from "node:assert";
 import { TINFOIL_CONFIG } from "../config";
 import { withMockedModules } from "./test-utils";
 
+const MOCK_MEASUREMENT_TYPE = "https://tinfoil.sh/predicate/sev-snp-guest/v1";
+
 describe("Secure transport integration", () => {
   it("configures the OpenAI SDK to use the encrypted body transport", async (t: TestContext) => {
     const verifyMock = t.mock.fn(async () => ({
       tlsPublicKeyFingerprint: "fingerprint",
       hpkePublicKey: "mock-hpke-public-key",
-      measurement: { type: "eif", registers: [] },
+      measurement: { type: MOCK_MEASUREMENT_TYPE, registers: [] },
     }));
     const mockFetch = t.mock.fn(async () => new Response(null));
     const createEncryptedBodyFetchMock = t.mock.fn(
@@ -46,11 +48,11 @@ describe("Secure transport integration", () => {
                 configRepo: "test-repo",
                 enclaveHost: "test-host",
                 digest: "test-digest",
-                codeMeasurement: { type: "eif", registers: [] },
+                codeMeasurement: { type: MOCK_MEASUREMENT_TYPE, registers: [] },
                 enclaveMeasurement: {
                   tlsPublicKeyFingerprint: "fingerprint",
                   hpkePublicKey: "mock-hpke-public-key",
-                  measurement: { type: "eif", registers: [] },
+                  measurement: { type: MOCK_MEASUREMENT_TYPE, registers: [] },
                 },
                 match: true,
               };
@@ -94,7 +96,7 @@ describe("Secure transport integration", () => {
     const verifyMock = t.mock.fn(async () => ({
       tlsPublicKeyFingerprint: "fingerprint",
       hpkePublicKey: "mock-hpke-public-key",
-      measurement: { type: "eif", registers: [] },
+      measurement: { type: MOCK_MEASUREMENT_TYPE, registers: [] },
     }));
     const mockFetch = t.mock.fn(async () => new Response(null));
     const createEncryptedBodyFetchMock = t.mock.fn(
@@ -116,11 +118,11 @@ describe("Secure transport integration", () => {
                 configRepo: "test-repo",
                 enclaveHost: "test-host",
                 digest: "test-digest",
-                codeMeasurement: { type: "eif", registers: [] },
+                codeMeasurement: { type: MOCK_MEASUREMENT_TYPE, registers: [] },
                 enclaveMeasurement: {
                   tlsPublicKeyFingerprint: "fingerprint",
                   hpkePublicKey: "mock-hpke-public-key",
-                  measurement: { type: "eif", registers: [] },
+                  measurement: { type: MOCK_MEASUREMENT_TYPE, registers: [] },
                 },
                 match: true,
               };

--- a/src/__tests__/security.enforcement.test.ts
+++ b/src/__tests__/security.enforcement.test.ts
@@ -5,6 +5,7 @@ import { withMockedModules } from "./test-utils";
 import { encryptedBodyRequest, createEncryptedBodyFetch } from "../encrypted-body-fetch";
 
 const MOCK_FP = "a3b1c5d7e9f0a1b2c3d4e5f60718293a4b5c6d7e8f9a0b1c2d3e4f506172839a";
+const MOCK_MEASUREMENT_TYPE = "https://tinfoil.sh/predicate/sev-snp-guest/v1";
 
 describe("Security enforcement", () => {
   it("EHBP helpers reject HTTP URLs and baseURL", async () => {
@@ -27,7 +28,7 @@ describe("Security enforcement", () => {
     const verifyMock = t.mock.fn(async () => ({
       tlsPublicKeyFingerprint: MOCK_FP,
       // No HPKE key triggers TLS fallback
-      measurement: { type: "eif", registers: [] },
+      measurement: { type: MOCK_MEASUREMENT_TYPE, registers: [] },
     }));
 
     let capturedFetch: typeof fetch | undefined;
@@ -49,10 +50,10 @@ describe("Security enforcement", () => {
                 configRepo: "owner/repo",
                 enclaveHost: "insecure.test",
                 releaseDigest: "deadbeef",
-                codeMeasurement: { type: "eif", registers: [] },
+                codeMeasurement: { type: MOCK_MEASUREMENT_TYPE, registers: [] },
                 enclaveMeasurement: {
                   tlsPublicKeyFingerprint: MOCK_FP,
-                  measurement: { type: "eif", registers: [] },
+                  measurement: { type: MOCK_MEASUREMENT_TYPE, registers: [] },
                 },
                 match: true,
               };
@@ -78,7 +79,7 @@ describe("Security enforcement", () => {
   it("AI SDK provider TLS fallback uses pinned fetch that rejects HTTP", async (t: TestContext) => {
     const verifyMock = t.mock.fn(async () => ({
       tlsPublicKeyFingerprint: MOCK_FP,
-      measurement: { type: "eif", registers: [] },
+      measurement: { type: MOCK_MEASUREMENT_TYPE, registers: [] },
     }));
 
     let capturedFetch: typeof fetch | undefined;
@@ -100,10 +101,10 @@ describe("Security enforcement", () => {
                 configRepo: "owner/repo",
                 enclaveHost: "secure.test",
                 releaseDigest: "deadbeef",
-                codeMeasurement: { type: "eif", registers: [] },
+                codeMeasurement: { type: MOCK_MEASUREMENT_TYPE, registers: [] },
                 enclaveMeasurement: {
                   tlsPublicKeyFingerprint: MOCK_FP,
-                  measurement: { type: "eif", registers: [] },
+                  measurement: { type: MOCK_MEASUREMENT_TYPE, registers: [] },
                 },
                 match: true,
               };
@@ -127,4 +128,3 @@ describe("Security enforcement", () => {
     );
   });
 });
-

--- a/src/__tests__/verifier.mismatch.test.ts
+++ b/src/__tests__/verifier.mismatch.test.ts
@@ -7,6 +7,8 @@ function makeHex64(): string {
   return "b".repeat(64);
 }
 
+const MOCK_MEASUREMENT_TYPE = "https://tinfoil.sh/predicate/sev-snp-guest/v1";
+
 describe("Verifier verify() failure when code attestation mismatches", () => {
   it("throws if verifyEnclave succeeds but verifyCode mismatches", async (t: TestContext) => {
     const fetchMock = t.mock.fn(async (input: RequestInfo) => {
@@ -47,13 +49,13 @@ describe("Verifier verify() failure when code attestation mismatches", () => {
           };
           // Runtime attestation succeeds and returns HPKE key
           (globalThis as any).verifyEnclave = async (_h: string) => ({
-            measurement: { type: "eif", registers: ["r1", "r2"] },
+            measurement: { type: MOCK_MEASUREMENT_TYPE, registers: ["r1", "r2"] },
             tls_public_key: "tls-fp",
             hpke_public_key: "hpke-key",
           });
           // Code attestation returns a different measurement -> mismatch
           (globalThis as any).verifyCode = async (_r: string, _d: string) => ({
-            type: "eif",
+            type: MOCK_MEASUREMENT_TYPE,
             registers: ["r1", "DIFFERENT"],
           });
 
@@ -73,5 +75,4 @@ describe("Verifier verify() failure when code attestation mismatches", () => {
     }
   });
 });
-
 

--- a/src/__tests__/verifier.test.ts
+++ b/src/__tests__/verifier.test.ts
@@ -7,6 +7,8 @@ function makeHex64(): string {
   return "a".repeat(64);
 }
 
+const MOCK_MEASUREMENT_TYPE = "https://tinfoil.sh/predicate/sev-snp-guest/v1";
+
 describe("Verifier helpers", () => {
   it("loadVerifier + runVerification success flow with updates", async (t: TestContext) => {
     const fetchMock = t.mock.fn(async (input: RequestInfo) => {
@@ -47,14 +49,15 @@ describe("Verifier helpers", () => {
             }
           };
           (globalThis as any).verifyEnclave = async (_h: string) => ({
-            measurement: { type: "eif", registers: ["r1", "r2"] },
+            measurement: { type: MOCK_MEASUREMENT_TYPE, registers: ["r1", "r2"] },
             tls_public_key: "tls-fp",
             hpke_public_key: "hpke-key",
           });
-          (globalThis as any).verifyCode = async (_r: string, _d: string) => ({
-            type: "eif",
-            registers: ["r1", "r2"],
-          });
+          (globalThis as any).verifyCode = async (_r: string, _d: string) =>
+            JSON.stringify({
+              type: MOCK_MEASUREMENT_TYPE,
+              registers: ["r1", "r2"],
+            });
 
           const { loadVerifier } = await import("../verification-runner");
           const client = await loadVerifier();
@@ -74,7 +77,7 @@ describe("Verifier helpers", () => {
           assert.strictEqual(result.verification.status, "success");
           assert.strictEqual(result.verification.securityVerified, true);
           assert.strictEqual(result.runtime.status, "success");
-          assert.deepStrictEqual(result.runtime.measurement, { type: "eif", registers: ["r1", "r2"] });
+          assert.deepStrictEqual(result.runtime.measurement, { type: MOCK_MEASUREMENT_TYPE, registers: ["r1", "r2"] });
           assert.strictEqual(result.runtime.tlsPublicKeyFingerprint, "tls-fp");
           assert.strictEqual(result.runtime.hpkePublicKey, "hpke-key");
           assert.strictEqual(typeof result.releaseDigest, "string");
@@ -128,11 +131,11 @@ describe("Verifier helpers", () => {
             }
           };
           (globalThis as any).verifyEnclave = async (_h: string) => ({
-            measurement: { type: "eif", registers: ["r1"] },
+            measurement: { type: MOCK_MEASUREMENT_TYPE, registers: ["r1"] },
             // Missing keys on purpose
           });
           (globalThis as any).verifyCode = async (_r: string, _d: string) => ({
-            type: "eif",
+            type: MOCK_MEASUREMENT_TYPE,
             registers: ["r1"],
           });
 
@@ -184,12 +187,12 @@ describe("Verifier helpers", () => {
             }
           };
           (globalThis as any).verifyEnclave = async (_h: string) => ({
-            measurement: { type: "eif", registers: ["x"] },
+            measurement: { type: MOCK_MEASUREMENT_TYPE, registers: ["x"] },
             tls_public_key: "fp",
             hpke_public_key: "hpke",
           });
           (globalThis as any).verifyCode = async (_r: string, _d: string) => ({
-            type: "eif",
+            type: MOCK_MEASUREMENT_TYPE,
             registers: ["x"],
           });
 

--- a/src/ai-sdk-provider.browser.ts
+++ b/src/ai-sdk-provider.browser.ts
@@ -1,0 +1,48 @@
+import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
+import { TINFOIL_CONFIG } from "./config";
+import { createEncryptedBodyFetch } from "./encrypted-body-fetch";
+import { Verifier } from "./verifier";
+import { isRealBrowser } from "./env";
+
+interface CreateTinfoilAIOptions {
+  baseURL?: string;
+  configRepo?: string;
+}
+
+export async function createTinfoilAI(apiKey: string, options: CreateTinfoilAIOptions = {}) {
+  const baseURL = options.baseURL || TINFOIL_CONFIG.INFERENCE_BASE_URL;
+  const configRepo = options.configRepo || TINFOIL_CONFIG.INFERENCE_PROXY_REPO;
+
+  assertHttpsUrl(baseURL, "Inference baseURL");
+
+  const verifier = new Verifier({ serverURL: baseURL, configRepo });
+  const attestationResponse = await verifier.verify();
+  const hpkePublicKey = attestationResponse.hpkePublicKey;
+
+  if (!hpkePublicKey) {
+    if (isRealBrowser()) {
+      throw new Error(
+        "HPKE public key not available and TLS-only verification is not supported in browsers. " +
+        "Only HPKE-enabled enclaves can be used in browser environments."
+      );
+    }
+    throw new Error("HPKE public key is required in browser environments");
+  }
+
+  const fetchFunction = createEncryptedBodyFetch(baseURL, hpkePublicKey);
+
+  return createOpenAICompatible({
+    name: "tinfoil",
+    baseURL: baseURL.replace(/\/$/, ""),
+    apiKey: apiKey,
+    fetch: fetchFunction,
+  });
+}
+
+function assertHttpsUrl(url: string, context: string): void {
+  const parsed = new URL(url);
+  if (parsed.protocol !== "https:") {
+    throw new Error(`${context} must use HTTPS. Got: ${url}`);
+  }
+}
+

--- a/src/client.browser.ts
+++ b/src/client.browser.ts
@@ -140,6 +140,14 @@ export class TinfoilAI {
     return this.client!;
   }
 
+  public async getVerificationDocument(): Promise<VerificationDocument> {
+    await this.ready();
+    if (!this.verificationDocument) {
+      throw new Error("Verification document unavailable: client not verified yet");
+    }
+    return this.verificationDocument;
+  }
+
   get chat(): Chat {
     return createAsyncProxy(this.ensureReady().then((client) => client.chat));
   }

--- a/src/client.browser.ts
+++ b/src/client.browser.ts
@@ -1,0 +1,205 @@
+import OpenAI from "openai";
+import type {
+  Audio,
+  Beta,
+  Chat,
+  Embeddings,
+  Files,
+  FineTuning,
+  Images,
+  Models,
+  Moderations,
+  Responses,
+} from "openai/resources";
+import { Verifier } from "./verifier";
+import type { VerificationDocument } from "./verifier";
+import { TINFOIL_CONFIG } from "./config";
+import { createEncryptedBodyFetch } from "./encrypted-body-fetch";
+import { isRealBrowser } from "./env";
+
+function createAsyncProxy<T extends object>(promise: Promise<T>): T {
+  return new Proxy({} as T, {
+    get(target, prop) {
+      return new Proxy(() => {}, {
+        get(_, nestedProp) {
+          return (...args: any[]) =>
+            promise.then((obj) => {
+              const value = (obj as any)[prop][nestedProp];
+              return typeof value === "function"
+                ? value.apply((obj as any)[prop], args)
+                : value;
+            });
+        },
+        apply(_, __, args) {
+          return promise.then((obj) => {
+            const value = (obj as any)[prop];
+            return typeof value === "function" ? value.apply(obj, args) : value;
+          });
+        },
+      });
+    },
+  });
+}
+
+interface TinfoilAIOptions {
+  apiKey?: string;
+  baseURL?: string;
+  configRepo?: string;
+  [key: string]: any;
+}
+
+export class TinfoilAI {
+  private client?: OpenAI;
+  private clientPromise: Promise<OpenAI>;
+  private readyPromise?: Promise<void>;
+  private configRepo?: string;
+  private verificationDocument?: VerificationDocument;
+
+  public apiKey?: string;
+  public baseURL?: string;
+
+  constructor(options: TinfoilAIOptions = {}) {
+    const openAIOptions = { ...options };
+    // In browser builds, never read secrets from process.env to avoid
+    // leaking credentials into client bundles. Require explicit apiKey.
+    if (typeof options.apiKey === "string") {
+      openAIOptions.apiKey = options.apiKey;
+    }
+
+    this.apiKey = openAIOptions.apiKey;
+    this.baseURL = options.baseURL || TINFOIL_CONFIG.INFERENCE_BASE_URL;
+    assertHttpsUrl(this.baseURL, "Inference baseURL");
+    this.configRepo = options.configRepo || TINFOIL_CONFIG.INFERENCE_PROXY_REPO;
+
+    this.clientPromise = this.initClient(openAIOptions);
+  }
+
+  public async ready(): Promise<void> {
+    if (!this.readyPromise) {
+      this.readyPromise = (async () => {
+        this.client = await this.clientPromise;
+      })();
+    }
+    return this.readyPromise;
+  }
+
+  private async initClient(
+    options?: Partial<Omit<ConstructorParameters<typeof OpenAI>[0], "baseURL">>,
+  ): Promise<OpenAI> {
+    return this.createOpenAIClient(options);
+  }
+
+  private async createOpenAIClient(
+    options: Partial<
+      Omit<ConstructorParameters<typeof OpenAI>[0], "baseURL">
+    > = {},
+  ): Promise<OpenAI> {
+    const verifier = new Verifier({
+      serverURL: this.baseURL,
+      configRepo: this.configRepo,
+    });
+
+    try {
+      await verifier.verify();
+      this.verificationDocument = verifier.getVerificationDocument();
+      if (!this.verificationDocument) {
+        throw new Error("Verification document not available after successful verification");
+      }
+    } catch (error) {
+      throw new Error(`Failed to verify enclave: ${error}`);
+    }
+
+    const hpkePublicKey = this.verificationDocument.enclaveMeasurement.hpkePublicKey;
+    if (!hpkePublicKey) {
+      // In browsers we require HPKE; TLS pinning fallback is Node-only
+      if (isRealBrowser()) {
+        throw new Error(
+          "HPKE public key not available and TLS-only verification is not supported in browsers. " +
+          "Only HPKE-enabled enclaves can be used in browser environments."
+        );
+      }
+      throw new Error("HPKE public key is required in browser environments");
+    }
+
+    const fetchFunction = createEncryptedBodyFetch(this.baseURL!, hpkePublicKey);
+
+    const clientOptions: ConstructorParameters<typeof OpenAI>[0] = {
+      ...options,
+      baseURL: this.baseURL,
+      fetch: fetchFunction,
+    };
+
+    // In browser usage, OpenAI SDK typically needs dangerouslyAllowBrowser
+    clientOptions.dangerouslyAllowBrowser = true;
+
+    return new OpenAI(clientOptions);
+  }
+
+  private async ensureReady(): Promise<OpenAI> {
+    await this.ready();
+    return this.client!;
+  }
+
+  get chat(): Chat {
+    return createAsyncProxy(this.ensureReady().then((client) => client.chat));
+  }
+  get files(): Files {
+    return createAsyncProxy(this.ensureReady().then((client) => client.files));
+  }
+  get fineTuning(): FineTuning {
+    return createAsyncProxy(
+      this.ensureReady().then((client) => client.fineTuning),
+    );
+  }
+  get images(): Images {
+    return createAsyncProxy(this.ensureReady().then((client) => client.images));
+  }
+  get audio(): Audio {
+    return createAsyncProxy(this.ensureReady().then((client) => client.audio));
+  }
+  get responses(): Responses {
+    return createAsyncProxy(
+      this.ensureReady().then((client) => client.responses),
+    );
+  }
+  get embeddings(): Embeddings {
+    return createAsyncProxy(
+      this.ensureReady().then((client) => client.embeddings),
+    );
+  }
+  get models(): Models {
+    return createAsyncProxy(this.ensureReady().then((client) => client.models));
+  }
+  get moderations(): Moderations {
+    return createAsyncProxy(
+      this.ensureReady().then((client) => client.moderations),
+    );
+  }
+  get beta(): Beta {
+    return createAsyncProxy(this.ensureReady().then((client) => client.beta));
+  }
+}
+
+export namespace TinfoilAI {
+  export import Chat = OpenAI.Chat;
+  export import Audio = OpenAI.Audio;
+  export import Beta = OpenAI.Beta;
+  export import Batches = OpenAI.Batches;
+  export import Completions = OpenAI.Completions;
+  export import Embeddings = OpenAI.Embeddings;
+  export import Files = OpenAI.Files;
+  export import FineTuning = OpenAI.FineTuning;
+  export import Images = OpenAI.Images;
+  export import Models = OpenAI.Models;
+  export import Moderations = OpenAI.Moderations;
+  export import Responses = OpenAI.Responses;
+  export import Uploads = OpenAI.Uploads;
+  export import VectorStores = OpenAI.VectorStores;
+}
+
+function assertHttpsUrl(url: string, context: string): void {
+  const parsed = new URL(url);
+  if (parsed.protocol !== "https:") {
+    throw new Error(`${context} must use HTTPS. Got: ${url}`);
+  }
+}

--- a/src/index.browser.ts
+++ b/src/index.browser.ts
@@ -1,0 +1,9 @@
+// Browser-safe entry point: avoids Node built-ins
+export { TinfoilAI } from "./client.browser";
+export { TinfoilAI as default } from "./client.browser";
+
+export * from "./verifier";
+export * from "./verification-runner";
+export * from "./ai-sdk-provider.browser";
+export * from "./config";
+

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -7,7 +7,7 @@ declare global {
     tls_public_key: string;
     hpke_public_key: string;
   }>;
-  let verifyCode: (configRepo: string, digest: string) => Promise<AttestationMeasurement>;
+  let verifyCode: (configRepo: string, digest: string) => Promise<AttestationMeasurement | string>;
 }
 
 export {};


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Adds first-class browser support using HPKE-encrypted requests and enclave attestation, with a browser-safe client and OpenAI-compatible provider. Updates exports to serve browser builds by default and enforce HTTPS/HPKE in the browser.

- **New Features**
  - Added TinfoilAI browser client that verifies the enclave, uses HPKE via encrypted fetch, and proxies OpenAI resources (chat, images, etc.).
  - Added createTinfoilAI for @ai-sdk/openai-compatible with encrypted fetch and attestation.
  - Introduced browser entry point (index.browser.ts) and updated package exports/subpaths (./client, ./ai-sdk-provider) with browser fields.

- **Migration**
  - Use HTTPS base URLs only.
  - Browsers require HPKE-enabled enclaves; TLS pinning fallback is Node-only.
  - Importing from the package in browsers resolves to the .browser build; you can also import from ./client or ./ai-sdk-provider.

<!-- End of auto-generated description by cubic. -->

