### PR TITLE
chore: bump version

### DIFF
--- a/examples/chat/main.ts
+++ b/examples/chat/main.ts
@@ -21,7 +21,10 @@ async function main() {
     await runVerificationDemo();
 
     // 5) Create a client and run the streaming chat example
-    const client = new TinfoilAI({}); // apiKey is read from TINFOIL_API_KEY
+    const client = new TinfoilAI({
+      baseURL: "https://ehbp.inf6.tinfoil.sh/v1/",
+      configRepo: "tinfoilsh/confidential-inference-proxy-hpke",
+    }); // apiKey is read from TINFOIL_API_KEY
     await runStreamingExample(client);
   } catch (error) {
     console.error("Main error:", error);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tinfoil",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Tinfoil secure OpenAI client wrapper",
   "main": "dist/index.js",
   "module": "dist/esm/index.js",

--- a/src/__tests__/client.inference-tinfoil.test.ts
+++ b/src/__tests__/client.inference-tinfoil.test.ts
@@ -19,8 +19,8 @@ describe("TinfoilAI - inference.tinfoil.sh integration", () => {
     }
     const client = new TinfoilAI({
       apiKey: API_KEY,
-      baseURL: "https://inference.tinfoil.sh/v1/",
-      configRepo: "tinfoilsh/confidential-inference-proxy",
+      baseURL: "https://ehbp.inf6.tinfoil.sh/v1/",
+      configRepo: "tinfoilsh/confidential-inference-proxy-hpke",
     });
 
     await client.ready();


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Switched examples and tests to the new HPKE inference proxy and bumped the package version to 0.8.2.

- **Refactors**
  - Updated client config in examples and tests to use baseURL https://ehbp.inf6.tinfoil.sh/v1/ and repo tinfoilsh/confidential-inference-proxy-hpke.

- **Dependencies**
  - package.json version updated to 0.8.2.

<!-- End of auto-generated description by cubic. -->

