### PR TITLE
feat: allow http endpoints for ehbp secured paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,9 @@ const completion = await client.chat.completions.create({
 - WebAssembly support for enclave verification
 - Secure context (HTTPS or localhost) with WebCrypto SubtleCrypto (required by EHBP)
 
+> **Note**
+> The EHBP transport now accepts `http://` origins (for example when developing against a `localhost` proxy). Payloads remain HPKE-encrypted end to end, while TLS-only fallback logic continues to require HTTPS because it relies on certificate pinning.
+
 
 ## Verification helpers
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tinfoil",
-  "version": "0.8.0",
+  "version": "0.8.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tinfoil",
-      "version": "0.8.0",
+      "version": "0.8.2",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@ai-sdk/openai-compatible": "^1.0.10",

--- a/src/ai-sdk-provider.browser.ts
+++ b/src/ai-sdk-provider.browser.ts
@@ -13,8 +13,6 @@ export async function createTinfoilAI(apiKey: string, options: CreateTinfoilAIOp
   const baseURL = options.baseURL || TINFOIL_CONFIG.INFERENCE_BASE_URL;
   const configRepo = options.configRepo || TINFOIL_CONFIG.INFERENCE_PROXY_REPO;
 
-  assertHttpsUrl(baseURL, "Inference baseURL");
-
   const verifier = new Verifier({ serverURL: baseURL, configRepo });
   const attestationResponse = await verifier.verify();
   const hpkePublicKey = attestationResponse.hpkePublicKey;
@@ -38,11 +36,3 @@ export async function createTinfoilAI(apiKey: string, options: CreateTinfoilAIOp
     fetch: fetchFunction,
   });
 }
-
-function assertHttpsUrl(url: string, context: string): void {
-  const parsed = new URL(url);
-  if (parsed.protocol !== "https:") {
-    throw new Error(`${context} must use HTTPS. Got: ${url}`);
-  }
-}
-

--- a/src/ai-sdk-provider.ts
+++ b/src/ai-sdk-provider.ts
@@ -27,8 +27,6 @@ export async function createTinfoilAI(apiKey: string, options: CreateTinfoilAIOp
   const baseURL = options.baseURL || TINFOIL_CONFIG.INFERENCE_BASE_URL;
   const configRepo = options.configRepo || TINFOIL_CONFIG.INFERENCE_PROXY_REPO;
 
-  assertHttpsUrl(baseURL, "Inference baseURL");
-
   // step 1: verify the enclave and extract the public keys
   // from the attestation response
   const verifier = new Verifier({ serverURL: baseURL, configRepo });
@@ -68,13 +66,6 @@ export async function createTinfoilAI(apiKey: string, options: CreateTinfoilAIOp
     apiKey: apiKey,
     fetch: fetchFunction,
   });
-}
-
-function assertHttpsUrl(url: string, context: string): void {
-  const parsed = new URL(url);
-  if (parsed.protocol !== "https:") {
-    throw new Error(`${context} must use HTTPS. Got: ${url}`);
-  }
 }
 
 function createPinnedTlsFetch(expectedFingerprintHex: string): typeof fetch {

--- a/src/client.browser.ts
+++ b/src/client.browser.ts
@@ -68,7 +68,6 @@ export class TinfoilAI {
 
     this.apiKey = openAIOptions.apiKey;
     this.baseURL = options.baseURL || TINFOIL_CONFIG.INFERENCE_BASE_URL;
-    assertHttpsUrl(this.baseURL, "Inference baseURL");
     this.configRepo = options.configRepo || TINFOIL_CONFIG.INFERENCE_PROXY_REPO;
 
     this.clientPromise = this.initClient(openAIOptions);
@@ -203,11 +202,4 @@ export namespace TinfoilAI {
   export import Responses = OpenAI.Responses;
   export import Uploads = OpenAI.Uploads;
   export import VectorStores = OpenAI.VectorStores;
-}
-
-function assertHttpsUrl(url: string, context: string): void {
-  const parsed = new URL(url);
-  if (parsed.protocol !== "https:") {
-    throw new Error(`${context} must use HTTPS. Got: ${url}`);
-  }
 }

--- a/src/client.ts
+++ b/src/client.ts
@@ -115,7 +115,6 @@ export class TinfoilAI {
     // Store properties for compatibility
     this.apiKey = openAIOptions.apiKey;
     this.baseURL = options.baseURL || TINFOIL_CONFIG.INFERENCE_BASE_URL;
-    assertHttpsUrl(this.baseURL, "Inference baseURL");
     this.configRepo =
       options.configRepo || TINFOIL_CONFIG.INFERENCE_PROXY_REPO;
 
@@ -332,13 +331,6 @@ export namespace TinfoilAI {
   export import Responses = OpenAI.Responses;
   export import Uploads = OpenAI.Uploads;
   export import VectorStores = OpenAI.VectorStores;
-}
-
-function assertHttpsUrl(url: string, context: string): void {
-  const parsed = new URL(url);
-  if (parsed.protocol !== "https:") {
-    throw new Error(`${context} must use HTTPS. Got: ${url}`);
-  }
 }
 
 function createPinnedTlsFetch(expectedFingerprintHex: string): typeof fetch {

--- a/src/encrypted-body-fetch.ts
+++ b/src/encrypted-body-fetch.ts
@@ -47,9 +47,6 @@ export async function encryptedBodyRequest(
   );
 
   const u = new URL(requestUrl);
-  if (u.protocol !== 'https:') {
-    throw new Error(`HTTP connections are not allowed for EHBP. Use HTTPS. URL: ${requestUrl}`);
-  }
   const { origin } = u;
   const transport = await getTransportForOrigin(origin);
 
@@ -64,10 +61,6 @@ export async function encryptedBodyRequest(
 
 export function createEncryptedBodyFetch(baseURL: string, hpkePublicKey: string): typeof fetch {
   return (async (input: RequestInfo | URL, init?: RequestInit) => {
-    const base = new URL(baseURL);
-    if (base.protocol !== 'https:') {
-      throw new Error(`EHBP baseURL must use HTTPS. Got: ${baseURL}`);
-    }
     const normalized = normalizeEncryptedBodyRequestArgs(input, init);
     const targetUrl = new URL(normalized.url, baseURL);
 
@@ -112,11 +105,6 @@ async function getTransportForOrigin(origin: string): Promise<EhbpTransport> {
 
   const transportPromise = (async () => {
     const { Identity, createTransport } = await getEhbpModule();
-    const proto = new URL(origin).protocol;
-    if (proto !== 'https:') {
-      throw new Error(`EHBP requires HTTPS origin. Got: ${origin}`);
-    }
-    
     // Ensure we're in a secure context with WebCrypto Subtle available (required by EHBP)
     if (typeof globalThis !== 'undefined') {
       const isSecure = (globalThis as any).isSecureContext !== false;


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Allow HTTP origins for EHBP-secured endpoints to support localhost/proxy development. HPKE stays enforced end to end; TLS-pinned fallback still requires HTTPS.

- **New Features**
  - EHBP transport now accepts http:// origins; HTTPS-only checks removed from clients and encrypted-body-fetch.
  - Updated tests to verify HTTP is allowed with HPKE, and TLS fallback still blocks HTTP.
  - README updated with guidance on HTTP usage under EHBP.

<!-- End of auto-generated description by cubic. -->

