### PR TITLE
TLS pinned connection can use base URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ The chat example demonstrates both streaming chat completions and real-time atte
 2. Install dependencies:
 
 ```bash
-npm install
+npm run build
 ```
 
 3. Optionally create a `.env` file with your configuration:

--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ The chat example demonstrates both streaming chat completions and real-time atte
 2. Install dependencies:
 
 ```bash
+npm install
 npm run build
 ```
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -13,6 +13,7 @@
 Before running any examples, install the dependencies from the root directory:
 
 ```bash
+npm install
 npm run build
 ```
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -13,7 +13,7 @@
 Before running any examples, install the dependencies from the root directory:
 
 ```bash
-npm install
+npm run build
 ```
 
 ## Running Examples

--- a/src/pinned-tls-fetch.ts
+++ b/src/pinned-tls-fetch.ts
@@ -4,13 +4,13 @@ import { X509Certificate, createHash } from "crypto";
 import { Readable } from "stream";
 import { ReadableStream as NodeReadableStream } from "stream/web";
 
-export function createPinnedTlsFetch(expectedFingerprintHex: string): typeof fetch {
+export function createPinnedTlsFetch(baseURL: string, expectedFingerprintHex: string): typeof fetch {
   return (async (input: RequestInfo | URL, init?: RequestInit) => {
-    // Normalize URL
+    // Normalize URL with base URL support
     const makeURL = (value: RequestInfo | URL): URL => {
-      if (typeof value === "string") return new URL(value);
+      if (typeof value === "string") return new URL(value, baseURL);
       if (value instanceof URL) return value;
-      return new URL((value as Request).url);
+      return new URL((value as Request).url, baseURL);
     };
 
     const url = makeURL(input);

--- a/src/secure-fetch.ts
+++ b/src/secure-fetch.ts
@@ -22,7 +22,7 @@ let fetchFunction: typeof fetch;
           "Neither HPKE public key nor TLS public key fingerprint available for verification"
         );
       }
-      fetchFunction = createPinnedTlsFetch(tlsPublicKeyFingerprint);
+      fetchFunction = createPinnedTlsFetch(baseURL, tlsPublicKeyFingerprint);
     }
     return fetchFunction
 }


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Added base URL support to pinned TLS fetch so you can use relative URLs while keeping certificate pinning. Also wired secure-fetch to pass baseURL and updated READMEs to use npm run build.

- **New Features**
  - createPinnedTlsFetch now takes (baseURL, fingerprint) and normalizes URLs using the base.
  - Relative paths work with pinned TLS; absolute URLs continue to work.

<!-- End of auto-generated description by cubic. -->

