### PR TITLE
Jules/fix double transport

### DIFF
--- a/src/__tests__/security.enforcement.test.ts
+++ b/src/__tests__/security.enforcement.test.ts
@@ -116,11 +116,12 @@ describe("Security enforcement", () => {
         HPKE_CONFIG: {} as any,
       },
       async () => {
-        await encryptedBodyRequest("http://localhost:8080/v1/models", MOCK_HPKE_PUBLIC_KEY);
+        await encryptedBodyRequest("http://localhost:8080/v1/models", MOCK_HPKE_PUBLIC_KEY, undefined, "https://enclave.address.sh");
 
         const fetchThroughProxy = createEncryptedBodyFetch(
           "http://localhost:8080/v1/",
           MOCK_HPKE_PUBLIC_KEY,
+          "https://enclave.address.sh"
         );
         await fetchThroughProxy("models");
       },

--- a/src/__tests__/security.enforcement.test.ts
+++ b/src/__tests__/security.enforcement.test.ts
@@ -11,26 +11,42 @@ import {
 
 const MOCK_FP = "a3b1c5d7e9f0a1b2c3d4e5f60718293a4b5c6d7e8f9a0b1c2d3e4f506172839a";
 const MOCK_MEASUREMENT_TYPE = "https://tinfoil.sh/predicate/sev-snp-guest/v1";
+const MOCK_HPKE_PUBLIC_KEY = "hpke-key";
+
+// Mock PROTOCOL constants matching the actual EHBP module
+const MOCK_PROTOCOL = {
+  ENCAPSULATED_KEY_HEADER: 'Ehbp-Encapsulated-Key',
+  CLIENT_PUBLIC_KEY_HEADER: 'Ehbp-Client-Public-Key',
+  KEYS_MEDIA_TYPE: 'application/ohttp-keys',
+  KEYS_PATH: '/.well-known/hpke-keys',
+  FALLBACK_HEADER: 'Ehbp-Fallback'
+};
 
 describe("Security enforcement", () => {
   const mockEhbpModule = (
     transportRequest: (url: string, init?: RequestInit) => Promise<Response>,
     identityGenerate: () => Promise<unknown>,
   ) => ({
-    Identity: { generate: identityGenerate } as any,
+    Identity: { 
+      generate: identityGenerate,
+      unmarshalPublicConfig: async () => ({
+        getPublicKey: () => ({ /* mock public key */ })
+      })
+    } as any,
     createTransport: async () => ({
       request: async () => new Response(null),
-      getServerPublicKey: () => ({ __mockHex: "hpke-key" }),
+      getServerPublicKey: () => ({ __mockHex: MOCK_HPKE_PUBLIC_KEY }),
+      getServerPublicKeyHex: async () => MOCK_HPKE_PUBLIC_KEY,
     }),
     Transport: class {
       async getServerPublicKeyHex(): Promise<string> {
-        return "hpke-key";
+        return MOCK_HPKE_PUBLIC_KEY;
       }
       async request(): Promise<Response> {
         return new Response();
       }
     } as any,
-    PROTOCOL: {},
+    PROTOCOL: MOCK_PROTOCOL,
     HPKE_CONFIG: {},
   });
 
@@ -38,10 +54,27 @@ describe("Security enforcement", () => {
     stub: ReturnType<typeof mockEhbpModule>,
     run: () => Promise<void>,
   ) => {
+    // Mock global fetch for getHPKEKey function
+    const originalFetch = globalThis.fetch;
+    const mockFetch = async (url: string | URL | Request) => {
+      const urlString = url.toString();
+      if (urlString.includes(MOCK_PROTOCOL.KEYS_PATH)) {
+        // Mock the keys endpoint response with correct content type
+        return new Response(new Uint8Array([1, 2, 3, 4]), {
+          status: 200,
+          headers: { 'content-type': MOCK_PROTOCOL.KEYS_MEDIA_TYPE }
+        });
+      }
+      // For other requests, return a generic response
+      return new Response('OK', { status: 200 });
+    };
+    
     try {
+      globalThis.fetch = mockFetch as typeof globalThis.fetch;
       __setEhbpModuleForTests(stub as any);
       await run();
     } finally {
+      globalThis.fetch = originalFetch;
       __resetEhbpModuleStateForTests();
     }
   };
@@ -62,7 +95,7 @@ describe("Security enforcement", () => {
         return this.key;
       }
       async getServerPublicKeyHex(): Promise<string> {
-        return this.key.__mockHex;
+        return MOCK_HPKE_PUBLIC_KEY; // Return the expected mock key
       }
       async request(url: string, init?: RequestInit): Promise<Response> {
         return transportRequest(url, init);
@@ -71,18 +104,23 @@ describe("Security enforcement", () => {
 
     await withEhbpMock(
       {
-        Identity: { generate: identityGenerate } as any,
+        Identity: { 
+          generate: identityGenerate,
+          unmarshalPublicConfig: async () => ({
+            getPublicKey: () => ({ /* mock public key */ })
+          })
+        } as any,
         createTransport: mockEhbpModule(transportRequest, identityGenerate).createTransport,
         Transport: TransportStub as any,
-        PROTOCOL: {} as any,
+        PROTOCOL: MOCK_PROTOCOL as any,
         HPKE_CONFIG: {} as any,
       },
       async () => {
-        await encryptedBodyRequest("http://localhost:8080/v1/models", "hpke-key");
+        await encryptedBodyRequest("http://localhost:8080/v1/models", MOCK_HPKE_PUBLIC_KEY);
 
         const fetchThroughProxy = createEncryptedBodyFetch(
           "http://localhost:8080/v1/",
-          "hpke-key",
+          MOCK_HPKE_PUBLIC_KEY,
         );
         await fetchThroughProxy("models");
       },

--- a/src/encrypted-body-fetch.ts
+++ b/src/encrypted-body-fetch.ts
@@ -12,8 +12,12 @@ export async function getHPKEKey(enclaveURL: string) : Promise<CryptoKey> {
   const { Identity, PROTOCOL } = await getEhbpModule();
   const url = new URL(enclaveURL);
 
-  // Fetch server public key
   const keysURL = new URL(PROTOCOL.KEYS_PATH, enclaveURL);
+
+  if (keysURL.protocol !== 'https:') {
+    throw new Error(`HTTPS is required for remote key retrieval. Invalid protocol: ${keysURL.protocol}`);
+  }
+
   const response = await fetch(keysURL.toString());
 
   if (!response.ok) {

--- a/src/encrypted-body-fetch.ts
+++ b/src/encrypted-body-fetch.ts
@@ -8,6 +8,29 @@ let ehbpModulePromise: Promise<EhbpModule> | null = null;
 let ehbpModuleOverride: EhbpModule | undefined;
 
 // Public API
+
+export async function getHPKEKey(enclaveURL: string) : Promise<CryptoKey> {
+  const { Identity, PROTOCOL } = await getEhbpModule();
+  const url = new URL(enclaveURL);
+
+  // Fetch server public key
+  const keysURL = new URL(PROTOCOL.KEYS_PATH, enclaveURL);
+  const response = await fetch(keysURL.toString());
+
+  if (!response.ok) {
+    throw new Error(`Failed to get server public key: ${response.status}`);
+  }
+
+  const contentType = response.headers.get('content-type');
+  if (contentType !== PROTOCOL.KEYS_MEDIA_TYPE) {
+    throw new Error(`Invalid content type: ${contentType}`);
+  }
+
+  const keysData = new Uint8Array(await response.arrayBuffer());
+  const serverIdentity = await Identity.unmarshalPublicConfig(keysData);
+  return serverIdentity.getPublicKey();
+}
+
 export function normalizeEncryptedBodyRequestArgs(
   input: RequestInfo | URL,
   init?: RequestInit,
@@ -120,9 +143,7 @@ async function getTransportForOrigin(origin: string, keyOrigin: string): Promise
   const clientIdentity = await Identity.generate();
 
   // Fetch the server's HPKE public key from the dedicated key origin.
-  // TODO: clean up this code. EHBP should make it easy to fetch the key without creating a transport object.
-  const keyTransport = await createTransport(keyOrigin, clientIdentity);
-  const serverPublicKey = keyTransport.getServerPublicKey();
+  const serverPublicKey = await getHPKEKey(keyOrigin);
   const requestHost = new URL(origin).host;
   return new Transport(clientIdentity, requestHost, serverPublicKey);
 }

--- a/src/encrypted-body-fetch.ts
+++ b/src/encrypted-body-fetch.ts
@@ -8,7 +8,6 @@ let ehbpModulePromise: Promise<EhbpModule> | null = null;
 let ehbpModuleOverride: EhbpModule | undefined;
 
 // Public API
-
 export async function getHPKEKey(enclaveURL: string) : Promise<CryptoKey> {
   const { Identity, PROTOCOL } = await getEhbpModule();
   const url = new URL(enclaveURL);
@@ -127,7 +126,7 @@ function getEhbpModule(): Promise<EhbpModule> {
 }
 
 async function getTransportForOrigin(origin: string, keyOrigin: string): Promise<EhbpTransport> {
-  const { Identity, createTransport, Transport } = await getEhbpModule();
+  const { Identity, Transport } = await getEhbpModule();
 
   // Ensure secure browser context
   if (typeof globalThis !== 'undefined') {
@@ -139,10 +138,8 @@ async function getTransportForOrigin(origin: string, keyOrigin: string): Promise
     }
   }
 
-  // Create a single client identity to use for both key discovery and requests
   const clientIdentity = await Identity.generate();
 
-  // Fetch the server's HPKE public key from the dedicated key origin.
   const serverPublicKey = await getHPKEKey(keyOrigin);
   const requestHost = new URL(origin).host;
   return new Transport(clientIdentity, requestHost, serverPublicKey);


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Eliminated double transport initialization by fetching the server HPKE public key directly from the well-known keys endpoint. This simplifies request setup and avoids unnecessary transport creation.

- **Refactors**
  - Added getHPKEKey to fetch keys from /.well-known/hpke-keys and unmarshal via Identity.
  - Updated getTransportForOrigin to use getHPKEKey instead of creating a transport for key discovery.
  - Validates response status and content type (application/ohttp-keys) when fetching keys.

- **Bug Fixes**
  - Updated tests to mock PROTOCOL constants and global fetch for key retrieval.
  - Ensured consistent use of the mocked HPKE public key and removed assumptions about createTransport being called for key origin.

<!-- End of auto-generated description by cubic. -->

