### PR TITLE
Implement unverified client

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -6,11 +6,12 @@
 2. **secure_client** - Direct usage of the SecureClient for custom HTTP requests
 3. **ehbp_chat** - TinfoilAI client with EHBP configuration
 4. **ehbp_secure_client** - SecureClient with EHBP configuration
-5. **advanced_chat** - Advanced example with streaming chat and simple attestation UI
+5. **ehbp_unverified_client** - UnverifiedClient with EHBP configuration
+6. **advanced_chat** - Advanced example with streaming chat and simple attestation UI
 
 ## Installation
 
-Before running any examples, install the dependencies from the root directory:
+Before running any examples, install the dependencies from the root directory and build the library:
 
 ```bash
 npm install

--- a/examples/ehbp_unverified_client/main.ts
+++ b/examples/ehbp_unverified_client/main.ts
@@ -1,0 +1,32 @@
+import { UnverifiedClient } from "tinfoil";
+
+async function main() {
+  try {
+    const client = new UnverifiedClient({
+      baseURL: "https://ehbp.inf6.tinfoil.sh/v1/",
+      enclaveURL: "https://ehbp.inf6.tinfoil.sh/v1/",
+      configRepo: "tinfoilsh/confidential-inference-proxy-hpke",
+    });
+
+    const response = await client.fetch("/v1/chat/completions", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        model: "llama-free",
+        messages: [{ role: "user", content: "Hello!" }],
+      }),
+    });
+
+    console.log(response);
+
+    const responseBody = await response.text();
+    console.log("Response Body:", responseBody);
+  } catch (error) {
+    console.error("Error:", error);
+    process.exit(1);
+  }
+}
+
+main();

--- a/src/encrypted-body-fetch.ts
+++ b/src/encrypted-body-fetch.ts
@@ -64,7 +64,7 @@ export function normalizeEncryptedBodyRequestArgs(
 
 export async function encryptedBodyRequest(
   input: RequestInfo | URL,
-  hpkePublicKey: string,
+  hpkePublicKey?: string,
   init?: RequestInit,
   enclaveURL?: string,
 ): Promise<Response> {
@@ -83,15 +83,18 @@ export async function encryptedBodyRequest(
   }
   
   const transportInstance = await transport;
-  const transportKeyHash = await transportInstance.getServerPublicKeyHex(); 
-  if(transportKeyHash !== hpkePublicKey) {
-    throw new Error(`HPKE public key mismatch. Expected: ${hpkePublicKey}, Got: ${transportKeyHash}`);
+  
+  if (hpkePublicKey) {
+    const transportKeyHash = await transportInstance.getServerPublicKeyHex();
+    if (transportKeyHash !== hpkePublicKey) {
+      throw new Error(`HPKE public key mismatch. Expected: ${hpkePublicKey}, Got: ${transportKeyHash}`);
+    }
   }
 
   return transportInstance.request(requestUrl, requestInit);
 }
 
-export function createEncryptedBodyFetch(baseURL: string, hpkePublicKey: string, enclaveURL?: string): typeof fetch {
+export function createEncryptedBodyFetch(baseURL: string, hpkePublicKey?: string, enclaveURL?: string): typeof fetch {
   return (async (input: RequestInfo | URL, init?: RequestInit) => {
     const normalized = normalizeEncryptedBodyRequestArgs(input, init);
     const targetUrl = new URL(normalized.url, baseURL);

--- a/src/index.browser.ts
+++ b/src/index.browser.ts
@@ -6,3 +6,4 @@ export * from "./verifier";
 export * from "./ai-sdk-provider";
 export * from "./config";
 export { SecureClient } from "./secure-client";
+export { UnverifiedClient } from "./unverified-client";

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ export * from "./verifier";
 export * from "./ai-sdk-provider";
 export * from "./config";
 export { SecureClient} from "./secure-client";
+export { UnverifiedClient } from "./unverified-client";
 
 // Re-export OpenAI utility types and classes that users might need
 // Using public exports from the main OpenAI package instead of deep imports

--- a/src/unverified-client.ts
+++ b/src/unverified-client.ts
@@ -1,0 +1,51 @@
+import { TINFOIL_CONFIG } from "./config";
+import { createEncryptedBodyFetch } from "./encrypted-body-fetch";
+
+interface UnverifiedClientOptions {
+  baseURL?: string;
+  enclaveURL?: string;
+  configRepo?: string;
+}
+
+export class UnverifiedClient {
+  private initPromise: Promise<void> | null = null;
+  private _fetch: typeof fetch | null = null;
+  
+  private readonly baseURL: string;
+  private readonly enclaveURL: string;
+  private readonly configRepo: string;
+
+  constructor(options: UnverifiedClientOptions = {}) {
+    this.baseURL = options.baseURL || TINFOIL_CONFIG.INFERENCE_BASE_URL;
+    this.enclaveURL = options.enclaveURL || TINFOIL_CONFIG.ENCLAVE_URL;
+    this.configRepo = options.configRepo || TINFOIL_CONFIG.INFERENCE_PROXY_REPO;
+  }
+
+  public async ready(): Promise<void> {
+    if (!this.initPromise) {
+      this.initPromise = this.initUnverifiedClient();
+    }
+    return this.initPromise;
+  }
+
+  private async initUnverifiedClient(): Promise<void> {
+    this._fetch = createEncryptedBodyFetch(this.baseURL, undefined, this.enclaveURL);
+  }
+
+  public async getVerificationDocument(): Promise<void> {
+    if (!this.initPromise) {
+      await this.ready();
+    }
+    
+    await this.initPromise;
+
+    throw new Error("Verification document unavailable: this version of the client is unverified");
+  }
+
+  get fetch(): typeof fetch {
+    return async (input: RequestInfo | URL, init?: RequestInit) => {
+      await this.ready();
+      return this._fetch!(input, init);
+    };
+  }
+}


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Adds an UnverifiedClient to send encrypted requests without attestation, enabling EHBP usage without verification. Updates transport to make the HPKE key optional and validate only when provided.

- New Features
  - New UnverifiedClient with ready() and fetch(); getVerificationDocument throws.
  - EHBP example added and README updated to include build step; integration test verifies chat completions.
  - Exported UnverifiedClient in Node and browser entry points.

- Refactors
  - encrypted-body-fetch accepts an optional hpkePublicKey and only checks for mismatches when a key is supplied.

<!-- End of auto-generated description by cubic. -->

