### PR TITLE
ci: Github Actions hardening

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Set up Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,8 +5,7 @@ on:
     tags:
       - "v*"
 
-permissions:
-  contents: write
+permissions: {}
 
 jobs:
   release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,8 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "24"
+          # Disable caching in release flows to avoid cache poisoning supply chain attacks
+          package-manager-cache: false
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,12 +16,12 @@ jobs:
       id-token: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "24"
 
@@ -40,6 +40,6 @@ jobs:
         working-directory: packages/tinfoil
 
       - name: Create Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         with:
           generate_release_notes: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,6 @@ jobs:
         working-directory: packages/tinfoil
 
       - name: Create Release
-        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
-        with:
-          generate_release_notes: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release create "$GITHUB_REF_NAME" --generate-notes

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,10 +6,14 @@ on:
       - main
   pull_request:
 
+permissions: {}
+
 jobs:
   test:
     name: Test (Node ${{ matrix.node-version }})
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       matrix:
         node-version: [20, 22, 24]
@@ -66,6 +70,8 @@ jobs:
   test-bun:
     name: Test (Bun)
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,10 +14,10 @@ jobs:
       matrix:
         node-version: [20, 22, 24]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ matrix.node-version }}
           cache: "npm"
@@ -54,7 +54,7 @@ jobs:
           TINFOIL_API_KEY: ${{ secrets.TINFOIL_API_KEY }}
 
       - name: Upload test coverage
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: always()
         with:
           name: coverage-node-${{ matrix.node-version }}
@@ -65,12 +65,12 @@ jobs:
     name: Test (Bun)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "22"
           cache: "npm"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,8 @@ jobs:
         node-version: [20, 22, 24]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Set up Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -66,6 +68,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
 

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,28 @@
+name: zizmor - GitHub Actions security analysis
+
+on:
+  push:
+    branches: ["main"]
+    paths: [".github/workflows/**"]
+  pull_request:
+    branches: ["**"]
+    paths: [".github/workflows/**"]
+
+permissions: {}
+
+jobs:
+  zizmor:
+    name: Run zizmor
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3
+        with:
+          advanced-security: false

--- a/packages/tinfoil/test/atc.test.ts
+++ b/packages/tinfoil/test/atc.test.ts
@@ -14,7 +14,7 @@ describe("ATC API", () => {
       expect(bundle).toBeDefined();
       expect(bundle.domain).toBeDefined();
       expect(typeof bundle.domain).toBe("string");
-      expect(bundle.domain).toMatch(/\.tinfoil\.sh$/);
+      expect(bundle.domain).toMatch(/\.tinfoil\.(sh|dev)$/);
 
       // Verify enclave attestation report
       expect(bundle.enclaveAttestationReport).toBeDefined();
@@ -103,7 +103,7 @@ describe("ATC API", () => {
 
       expect(router).toBeDefined();
       expect(typeof router).toBe("string");
-      expect(router).toMatch(/\.tinfoil\.sh$/);
+      expect(router).toMatch(/\.tinfoil\.(sh|dev)$/);
     });
 
     it.skipIf(!RUN_INTEGRATION)("should accept custom ATC URL", async () => {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Hardens GitHub Actions to reduce supply chain risk and enforce least privilege. Pins and upgrades core actions, tightens permissions, disables token persistence and risky caches, adds `zizmor`, and updates tests to allow `tinfoil.dev` domains.

- **Refactors**
  - Harden permissions: workflow-level `{}`; per-job `contents: read` for tests and `id-token: write` for releases.
  - Replace `softprops/action-gh-release` with `gh` CLI using `GITHUB_TOKEN`.
  - Disable token persistence in `actions/checkout` and turn off `package-manager-cache` in releases; keep npm cache in tests.
  - Pin and upgrade actions to SHAs: `actions/checkout` (v6.0.2), `actions/setup-node` (v6.4.0), `actions/upload-artifact` (v4.6.2), `oven-sh/setup-bun` (v2.2.0).
  - Update ATC tests to accept `.tinfoil.(sh|dev)` domains.

- **New Features**
  - Add `zizmor` workflow to scan `.github/workflows/**` on push/PR for security issues.

<sup>Written for commit ea08d49c5b14922de9d7e2a32c228537467ae6d4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

