### PR TITLE
ci: Add nightly scanning and dependency cooldown

### DIFF
--- a/.github/workflows/npm-audit.yml
+++ b/.github/workflows/npm-audit.yml
@@ -1,0 +1,28 @@
+name: npm audit
+on:
+  # The actor associated with the schedule trigger will be the user who last
+  # modified the cron line below or who re-enables the workflow.
+  # See the following resources for more details:
+  # https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#actor-for-scheduled-workflows
+  # https://docs.github.com/en/actions/concepts/workflows-and-actions/notifications-for-workflow-runs
+  schedule: # daily at 10:47 UTC
+    - cron: '47 10 * * *'
+
+  workflow_dispatch:
+permissions:
+  contents: read
+jobs:
+  govulncheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "24"
+      - name: Scan for vulnerabilities
+        run: npm audit --omit=dev
+      - name: Check package provenance signatures
+        run: npm audit signatures

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@
 node_modules/
 .node-tests/
 .env
-.npmrc
 dist/
 packages/*/dist/
 packages/*/.node-tests/

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+min-release-age=4

--- a/package.json
+++ b/package.json
@@ -26,6 +26,9 @@
     "syncpack": "^14.3.0",
     "typescript": "^6.0.3"
   },
+  "engines": {
+    "npm": ">=11.10.0"
+  },
   "dependencies": {
     "@freedomofpress/crypto-browser": "^0.1.7",
     "@freedomofpress/sigstore-browser": "^0.1.13",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a nightly `npm audit` workflow and a dependency cooldown via `.npmrc` to reduce supply chain risk. The scan runs daily and verifies package provenance signatures.

- **New Features**
  - Nightly scan at 10:47 UTC, plus manual `workflow_dispatch`.
  - Runs `npm audit --omit=dev` and `npm audit signatures` on Node 24.
  - Tracks repo `.npmrc` with `min-release-age=4` and adds `engines.npm: ">=11.10.0"` so the cooldown is respected.

- **Migration**
  - Ensure no auth tokens or private registry creds are committed to `.npmrc`; note that older `npm` will ignore `min-release-age`.

<sup>Written for commit 1ad0556e53ddbd00e1a5c927274188ec2f3531e7. Summary will update on new commits. <a href="https://cubic.dev/pr/tinfoilsh/tinfoil-js/pull/161?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

