### PR TITLE
ci/fix: fix job name and missing dependency install

### DIFF
--- a/.github/workflows/npm-audit.yml
+++ b/.github/workflows/npm-audit.yml
@@ -22,6 +22,8 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "24"
+      - name: Install dependencies
+        run: npm ci
       - name: Scan for vulnerabilities
         run: npm audit --omit=dev
       - name: Check package provenance signatures

--- a/.github/workflows/npm-audit.yml
+++ b/.github/workflows/npm-audit.yml
@@ -12,7 +12,7 @@ on:
 permissions:
   contents: read
 jobs:
-  govulncheck:
+  npm-audit:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fix the `npm-audit` workflow by renaming the job (from `govulncheck`) and installing dependencies with `npm ci` before `npm audit --omit=dev`. This makes the job name accurate and ensures the audit runs against installed modules, avoiding empty or misleading results.

<sup>Written for commit 6d5de51c44dc641752481f2221bb56ae93e4ce65. Summary will update on new commits. <a href="https://cubic.dev/pr/tinfoilsh/tinfoil-js/pull/162?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

