### PR TITLE
fix: bind custom enclave attestation bundle to configured host

### DIFF
--- a/packages/tinfoil/src/secure-client.ts
+++ b/packages/tinfoil/src/secure-client.ts
@@ -221,6 +221,17 @@ export class SecureClient {
         : undefined,
     });
 
+    if (this.config.enclaveURL) {
+      const configuredHost = new URL(this.config.enclaveURL).hostname.toLowerCase();
+      const bundleDomain = bundle.domain.toLowerCase();
+
+      if (configuredHost !== bundleDomain) {
+        throw new Error(
+          `Attestation bundle domain mismatch: expected "${configuredHost}" but got "${bundleDomain}"`,
+        );
+      }
+    }
+
     // Resolve enclaveURL: user-provided config takes precedence, otherwise from bundle
     this.resolvedEnclaveURL = this.config.enclaveURL ?? `https://${bundle.domain}`;
 

--- a/packages/tinfoil/test/secure-client.test.ts
+++ b/packages/tinfoil/test/secure-client.test.ts
@@ -33,6 +33,13 @@ const verifyMock = vi.fn(async () => ({
 
 const mockFetch = vi.fn(async () => new Response(JSON.stringify({ message: "success" })));
 const mockGetSessionRecoveryToken = vi.fn(async () => ({ exportedSecret: new Uint8Array(), requestEnc: new Uint8Array() }));
+const fetchAttestationBundleMock = vi.fn(async () => ({
+  domain: "test-router.tinfoil.sh",
+  enclaveAttestationReport: { format: "test", body: "test" },
+  digest: "test-digest",
+  sigstoreBundle: {},
+  vcek: "test-vcek",
+}));
 const createSecureFetchMock = vi.fn(
   async (_baseURL: string, hpkePublicKey: string | undefined) => {
     if (hpkePublicKey) {
@@ -86,13 +93,7 @@ vi.mock("../src/secure-fetch.js", () => ({
 }));
 
 vi.mock("../src/atc.js", () => ({
-  fetchAttestationBundle: vi.fn(async () => ({
-    domain: "test-router.tinfoil.sh",
-    enclaveAttestationReport: { format: "test", body: "test" },
-    digest: "test-digest",
-    sigstoreBundle: {},
-    vcek: "test-vcek",
-  })),
+  fetchAttestationBundle: fetchAttestationBundleMock,
   fetchRouter: vi.fn(async () => "test-router.tinfoil.sh"),
 }));
 
@@ -160,6 +161,26 @@ describe("SecureClient", () => {
     // Only one attestation should have happened
     expect(verifyMock).toHaveBeenCalledTimes(1);
     expect(createSecureFetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("should reject mismatched bundle domain for custom enclaveURL", async () => {
+    fetchAttestationBundleMock.mockResolvedValueOnce({
+      domain: "attested-different.example",
+      enclaveAttestationReport: { format: "test", body: "test" },
+      digest: "test-digest",
+      sigstoreBundle: {},
+      vcek: "test-vcek",
+    });
+
+    const { SecureClient } = await import("../src/secure-client");
+
+    const client = new SecureClient({
+      enclaveURL: "https://requested-enclave.example",
+    });
+
+    await expect(client.ready()).rejects.toThrow("Attestation bundle domain mismatch");
+    expect(verifyMock).not.toHaveBeenCalled();
+    expect(createSecureFetchMock).not.toHaveBeenCalled();
   });
 
   it("should return pending verification document before ready()", async () => {


### PR DESCRIPTION
### Motivation
- Prevent ATC-returned attestation bundles from being accepted for a different domain than the user-configured enclave endpoint, restoring endpoint-authentication guarantees for custom enclaves.
- The existing flow verified the returned `bundle.domain` but continued to use the user-supplied `enclaveURL` for transport, allowing a verified bundle for one domain to be used while sending traffic to another.

### Description
- Add a host equality check in `SecureClient.initSecureClient()` that, when `config.enclaveURL` is provided, compares `new URL(this.config.enclaveURL).hostname` (case-insensitive) to `bundle.domain` and throws an error on mismatch before verification or transport setup.
- This prevents calling `verifier.verifyBundle(bundle)` and `createTransport(...)` when the ATC response does not match the configured enclave host.
- Add a focused unit test `should reject mismatched bundle domain for custom enclaveURL` in `packages/tinfoil/test/secure-client.test.ts` that mocks `fetchAttestationBundle` to return a different `domain` and asserts `client.ready()` rejects and no verifier/transport calls are made.
- Changes affect `packages/tinfoil/src/secure-client.ts` and `packages/tinfoil/test/secure-client.test.ts`.

### Testing
- Attempted `npm test -- packages/tinfoil/test/secure-client.test.ts` but no tests were discovered due to the workspace-level vitest include/exclude filter in this environment.
- Ran `npm run test -- test/secure-client.test.ts` inside `packages/tinfoil`, which executed the package tests but they failed (30 failing) due to an environment/missing dependency error: `Cannot find package 'ehbp' imported from /workspace/tinfoil-js/packages/tinfoil/src/secure-client.ts`.
- The new unit test reproduces the attacker scenario locally via mocks and is expected to pass in CI where dependencies are available; in this sandbox the run was blocked by the missing `ehbp` dependency rather than the behavioral change itself.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5afbf29f0833088ec8144a3699b55)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bind custom enclave attestation bundles to the configured host to restore endpoint authentication and block cross-domain misuse. `SecureClient` now rejects bundles when `bundle.domain` doesn’t match the `enclaveURL` host.

- **Bug Fixes**
  - Added a case-insensitive host check in `SecureClient.initSecureClient()` to compare `new URL(config.enclaveURL).hostname` with `bundle.domain` and throw on mismatch before verification or transport.
  - Added a focused test to ensure mismatched domains are rejected and no verifier or transport calls occur (`packages/tinfoil/src/secure-client.ts`, `packages/tinfoil/test/secure-client.test.ts`).

<sup>Written for commit ff728b6c15f78b9025ad6594bea51dc767946144. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

