### PR TITLE
Reject attestation bundle domain mismatch for custom enclaveURL and add tests

### DIFF
--- a/packages/tinfoil/src/secure-client.ts
+++ b/packages/tinfoil/src/secure-client.ts
@@ -221,6 +221,17 @@ export class SecureClient {
         : undefined,
     });
 
+    if (this.config.enclaveURL) {
+      const configuredHost = new URL(this.config.enclaveURL).hostname.toLowerCase();
+      const bundleDomain = bundle.domain.toLowerCase();
+
+      if (configuredHost !== bundleDomain) {
+        throw new AttestationError(
+          `Attestation bundle domain mismatch: expected "${configuredHost}" but got "${bundleDomain}"`,
+        );
+      }
+    }
+
     // Resolve enclaveURL: user-provided config takes precedence, otherwise from bundle
     this.resolvedEnclaveURL = this.config.enclaveURL ?? `https://${bundle.domain}`;
 

--- a/packages/tinfoil/test/secure-client.test.ts
+++ b/packages/tinfoil/test/secure-client.test.ts
@@ -33,6 +33,13 @@ const verifyMock = vi.fn(async () => ({
 
 const mockFetch = vi.fn(async () => new Response(JSON.stringify({ message: "success" })));
 const mockGetSessionRecoveryToken = vi.fn(async () => ({ exportedSecret: new Uint8Array(), requestEnc: new Uint8Array() }));
+const fetchAttestationBundleMock = vi.fn(async () => ({
+  domain: "test-router.tinfoil.sh",
+  enclaveAttestationReport: { format: "test", body: "test" },
+  digest: "test-digest",
+  sigstoreBundle: {},
+  vcek: "test-vcek",
+}));
 const createSecureFetchMock = vi.fn(
   async (_baseURL: string, hpkePublicKey: string | undefined) => {
     if (hpkePublicKey) {
@@ -86,13 +93,7 @@ vi.mock("../src/secure-fetch.js", () => ({
 }));
 
 vi.mock("../src/atc.js", () => ({
-  fetchAttestationBundle: vi.fn(async () => ({
-    domain: "test-router.tinfoil.sh",
-    enclaveAttestationReport: { format: "test", body: "test" },
-    digest: "test-digest",
-    sigstoreBundle: {},
-    vcek: "test-vcek",
-  })),
+  fetchAttestationBundle: fetchAttestationBundleMock,
   fetchRouter: vi.fn(async () => "test-router.tinfoil.sh"),
 }));
 
@@ -160,6 +161,27 @@ describe("SecureClient", () => {
     // Only one attestation should have happened
     expect(verifyMock).toHaveBeenCalledTimes(1);
     expect(createSecureFetchMock).toHaveBeenCalledTimes(1);
+  });
+
+
+  it("should reject mismatched bundle domain for custom enclaveURL", async () => {
+    fetchAttestationBundleMock.mockResolvedValueOnce({
+      domain: "attested-different.example",
+      enclaveAttestationReport: { format: "test", body: "test" },
+      digest: "test-digest",
+      sigstoreBundle: {},
+      vcek: "test-vcek",
+    });
+
+    const { SecureClient } = await import("../src/secure-client");
+
+    const client = new SecureClient({
+      enclaveURL: "https://requested-enclave.example",
+    });
+
+    await expect(client.ready()).rejects.toThrow("Attestation bundle domain mismatch");
+    expect(verifyMock).not.toHaveBeenCalled();
+    expect(createSecureFetchMock).not.toHaveBeenCalled();
   });
 
   it("should return pending verification document before ready()", async () => {
@@ -469,6 +491,14 @@ describe("SecureClient", () => {
       const { SecureClient } = await import("../src/secure-client");
       const { fetchAttestationBundle } = await import("../src/atc.js");
 
+      fetchAttestationBundleMock.mockResolvedValueOnce({
+        domain: "my-enclave.example.com",
+        enclaveAttestationReport: { format: "test", body: "test" },
+        digest: "test-digest",
+        sigstoreBundle: {},
+        vcek: "test-vcek",
+      });
+
       const client = new SecureClient({
         enclaveURL: "https://my-enclave.example.com",
         configRepo: "custom/repo",
@@ -568,6 +598,14 @@ describe("SecureClient", () => {
     it("Case 3: custom enclave — enclaveURL from config, baseURL derived", async () => {
       const { SecureClient } = await import("../src/secure-client");
 
+      fetchAttestationBundleMock.mockResolvedValueOnce({
+        domain: "my-enclave.example.com",
+        enclaveAttestationReport: { format: "test", body: "test" },
+        digest: "test-digest",
+        sigstoreBundle: {},
+        vcek: "test-vcek",
+      });
+
       const client = new SecureClient({
         enclaveURL: "https://my-enclave.example.com",
       });
@@ -586,6 +624,14 @@ describe("SecureClient", () => {
 
     it("Case 4: proxy + custom enclave — both from config", async () => {
       const { SecureClient } = await import("../src/secure-client");
+
+      fetchAttestationBundleMock.mockResolvedValueOnce({
+        domain: "my-enclave.example.com",
+        enclaveAttestationReport: { format: "test", body: "test" },
+        digest: "test-digest",
+        sigstoreBundle: {},
+        vcek: "test-vcek",
+      });
 
       const client = new SecureClient({
         baseURL: "https://my-proxy.com/api/",
@@ -606,6 +652,22 @@ describe("SecureClient", () => {
 
     it("Case 4: reset preserves proxy + custom enclave config", async () => {
       const { SecureClient } = await import("../src/secure-client");
+
+      fetchAttestationBundleMock
+        .mockResolvedValueOnce({
+          domain: "my-enclave.example.com",
+          enclaveAttestationReport: { format: "test", body: "test" },
+          digest: "test-digest",
+          sigstoreBundle: {},
+          vcek: "test-vcek",
+        })
+        .mockResolvedValueOnce({
+          domain: "my-enclave.example.com",
+          enclaveAttestationReport: { format: "test", body: "test" },
+          digest: "test-digest",
+          sigstoreBundle: {},
+          vcek: "test-vcek",
+        });
 
       const client = new SecureClient({
         baseURL: "https://my-proxy.com/api/",


### PR DESCRIPTION
### Motivation

- Ensure a user-provided `enclaveURL` cannot be silently paired with an attestation bundle for a different domain to prevent misconfiguration or security surprises.
- Expand unit test coverage for attestation bundle handling and enclave/base URL resolution paths.

### Description

- Add a domain check in `initSecureClient` that compares the hostname of a configured `enclaveURL` with `bundle.domain` and throws an error on mismatch.
- Preserve current resolution behavior for `resolvedEnclaveURL` and `resolvedBaseURL` when the domain matches or no custom `enclaveURL` is provided.
- Introduce `fetchAttestationBundleMock` in `packages/tinfoil/test/secure-client.test.ts` and update existing mocks to use it, add a new test `should reject mismatched bundle domain for custom enclaveURL`, and adapt several attestation-path tests to mock bundle domains as needed.

### Testing

- Ran package unit tests (Vitest) for `packages/tinfoil` and the test suite passed. 
- New test `should reject mismatched bundle domain for custom enclaveURL` passed and verifies the mismatch causes `client.ready()` to reject. 
- Existing and updated tests around attestation bundle paths, URL resolution, and reset behavior passed successfully.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reject attestation bundles when their domain doesn’t match a user-provided `enclaveURL`, binding attestation to the configured host to prevent misconfigurations and tighten security. Adds tests and a shared `fetchAttestationBundleMock` covering domain checks, URL resolution, and reset paths.

- **Bug Fixes**
  - Case-insensitive compare of `new URL(enclaveURL).hostname` to `bundle.domain` during client init; throw a clear `AttestationError` on mismatch.
  - Stop verification and secure-fetch creation when a mismatch is detected.
  - Preserve existing URL resolution when domains match or no custom `enclaveURL` is provided.

- **Refactors**
  - Introduced `fetchAttestationBundleMock` and updated tests to use it.
  - Added mismatch test and updated config-resolution and reset tests with aligned bundle domains.

<sup>Written for commit d6bbd820cd82a2499207da690db0e6bff1d252e9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



