### PR TITLE
fix(ci): isolate npm trusted publishing from release creation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: publish_verifier
     permissions:
+      contents: read
       id-token: write
     steps:
       - name: Checkout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,10 +8,9 @@ on:
 permissions: {}
 
 jobs:
-  release:
+  publish_verifier:
     runs-on: ubuntu-latest
     permissions:
-      contents: write
       id-token: write
     steps:
       - name: Checkout
@@ -30,17 +29,42 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Build
-        run: npm run build
-
       - name: Publish @tinfoilsh/verifier to npm
         run: npm publish --access public --provenance
         working-directory: packages/verifier
+
+  publish_tinfoil:
+    runs-on: ubuntu-latest
+    needs: publish_verifier
+    permissions:
+      id-token: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "24"
+          # Disable caching in release flows to avoid cache poisoning supply chain attacks
+          package-manager-cache: false
+
+      - name: Install dependencies
+        run: npm ci
 
       - name: Publish tinfoil to npm
         run: npm publish --access public --provenance
         working-directory: packages/tinfoil
 
+  create_release:
+    runs-on: ubuntu-latest
+    needs: publish_tinfoil
+    permissions:
+      contents: write
+    steps:
       - name: Create Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Motivation
- The previous `release` job granted `id-token: write` at the job level while running non-publish steps and release creation, allowing any step in the job to request OIDC tokens usable for trusted publishing.
- This creates a supply-chain risk where a compromised action or lifecycle script could publish tampered packages with valid provenance.
- The goal is to reduce the blast radius of OIDC authority by restricting `id-token: write` to minimal publish-only jobs.

### Description
- Split the single `release` job in `/.github/workflows/release.yml` into three jobs: `publish_verifier`, `publish_tinfoil`, and `create_release`.
- Each publish job (`publish_verifier` and `publish_tinfoil`) is OIDC-enabled with `permissions: id-token: write` and contains only the minimal steps to `checkout`, `setup-node`, `npm ci`, and `npm publish --access public --provenance` for the target package.
- The release creation task is moved to a separate `create_release` job that has only `permissions: contents: write` and no OIDC permission.
- Action references remain pinned by SHA and the existing publish commands and ordering are preserved via `needs` to avoid altering publish behavior.

### Testing
- No automated tests were run for this workflow change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Limits OIDC token exposure in the release workflow by isolating `id-token: write` to publish-only jobs. Splits release creation into its own job without OIDC, and adds only `contents: read` where checkout is required.

- **Refactors**
  - Split the old `release` job into `publish_verifier`, `publish_tinfoil`, and `create_release`.
  - Only the publish jobs have `permissions: id-token: write`; `create_release` has `contents: write` only.
  - Publish jobs run minimal steps (checkout, setup-node with cache disabled, npm ci, `npm publish --access public --provenance`) for `@tinfoilsh/verifier` and `tinfoil`.
  - Granted `contents: read` to the publish job that needs it for `actions/checkout`.

<sup>Written for commit 5a00c26728231c1bbc64608e91b722f1cd695d63. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

