### PR TITLE
fix: restore secure-context guard for browser EHBP transports

### DIFF
--- a/packages/tinfoil/src/encrypted-body-fetch.ts
+++ b/packages/tinfoil/src/encrypted-body-fetch.ts
@@ -96,6 +96,13 @@ export async function encryptedBodyRequest(
 
 const ENCLAVE_URL_HEADER = 'X-Tinfoil-Enclave-Url';
 
+
+function assertSecureBrowserContext(): void {
+  if (typeof window !== "undefined" && globalThis.isSecureContext === false) {
+    throw new ConfigurationError("EHBP encryption requires a secure browser context: Use HTTPS or localhost");
+  }
+}
+
 export function createEncryptedBodyFetch(baseURL: string, hpkePublicKey: string, enclaveURL?: string): SecureTransport {
   const baseOrigin = new URL(baseURL).origin;
   const needsEnclaveHeader = !!enclaveURL && new URL(enclaveURL).origin !== baseOrigin;
@@ -194,12 +201,14 @@ export function createUnverifiedEncryptedBodyFetch(baseURL: string, keyOrigin?: 
 }
 
 async function getUnverifiedTransportForOrigin(origin: string, keyOrigin: string): Promise<Transport> {
+  assertSecureBrowserContext();
   const serverIdentity = await getServerIdentity(keyOrigin);
   const requestHost = new URL(origin).host;
   return new Transport(serverIdentity, requestHost);
 }
 
 async function getTransportForOrigin(origin: string, hpkePublicKeyHex: string): Promise<Transport> {
+  assertSecureBrowserContext();
   const serverIdentity = await createIdentityFromPublicKeyHex(hpkePublicKeyHex);
   const requestHost = new URL(origin).host;
   return new Transport(serverIdentity, requestHost);

--- a/packages/tinfoil/test/encrypted-body-fetch.test.ts
+++ b/packages/tinfoil/test/encrypted-body-fetch.test.ts
@@ -156,6 +156,26 @@ describe("encrypted-body-fetch", () => {
 
       expect(apiRequestMade).toBe(true);
     });
+
+
+    it("rejects insecure browser contexts for verified transport", async () => {
+      const originalWindow = (globalThis as { window?: Window }).window;
+      const key = await (await Identity.generate()).getPublicKeyHex();
+
+      vi.stubGlobal("window", {} as Window);
+      vi.stubGlobal("isSecureContext", false);
+
+      try {
+        await expect(encryptedBodyRequest("https://api.example.com/test", key)).rejects.toThrow(
+          /secure browser context/
+        );
+      } finally {
+        vi.unstubAllGlobals();
+        if (originalWindow !== undefined) {
+          vi.stubGlobal("window", originalWindow);
+        }
+      }
+    });
   });
 
   describe("createEncryptedBodyFetch", () => {
@@ -253,6 +273,22 @@ describe("encrypted-body-fetch", () => {
       expect(keyFetchedFromEnclave).toBe(true);
     });
 
+
+    it("rejects insecure browser contexts", async () => {
+      const originalWindow = (globalThis as { window?: Window }).window;
+      vi.stubGlobal("window", {} as Window);
+      vi.stubGlobal("isSecureContext", false);
+
+      try {
+        const transport = createUnverifiedEncryptedBodyFetch("https://api.example.com");
+        await expect(transport.fetch("/test")).rejects.toThrow(/secure browser context/);
+      } finally {
+        vi.unstubAllGlobals();
+        if (originalWindow !== undefined) {
+          vi.stubGlobal("window", originalWindow);
+        }
+      }
+    });
     it("returns a SecureTransport object", () => {
       const transport = createUnverifiedEncryptedBodyFetch("https://api.example.com");
       expect(typeof transport).toBe("object");


### PR DESCRIPTION
### Motivation
- A regression removed the browser secure-context check and allowed EHBP transports to be constructed from non-HTTPS browser contexts, exposing bearer tokens and plaintext prompts before encryption.
- The intent is to fail closed for browser usage on insecure origins while preserving server/Node behavior and not reintroducing any WebCrypto `subtle` dependency checks.

### Description
- Restores a browser-only secure-context guard by adding `assertSecureBrowserContext()` and calling it from both `getTransportForOrigin` and `getUnverifiedTransportForOrigin` in `packages/tinfoil/src/encrypted-body-fetch.ts` so transport construction throws when `globalThis.isSecureContext === false` in a browser.
- The guard is only triggered in browser contexts (`typeof window !== "undefined"`) so Node/server usage is unchanged.
- Adds regression tests to `packages/tinfoil/test/encrypted-body-fetch.test.ts` that assert verified (`encryptedBodyRequest`) and unverified (`createUnverifiedEncryptedBodyFetch`) transport paths reject in insecure browser contexts.

### Testing
- Attempted to run the package tests with `npx vitest run test/encrypted-body-fetch.test.ts` in `packages/tinfoil`, but the test run failed in this environment due to a missing runtime dependency: `Cannot find package 'ehbp'` (tests were added but could not be executed here).
- Local targeted validation (static inspection + unit-style test scaffolding added) verifies the secure-context guard is invoked in both transport creation paths and tests for insecure contexts were added to the test file.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restore a browser-only secure-context guard for EHBP transports so they cannot be created on non-HTTPS pages. This prevents leaking tokens and plaintext before encryption and keeps Node/server behavior unchanged.

- **Bug Fixes**
  - Added `assertSecureBrowserContext()` in `packages/tinfoil/src/encrypted-body-fetch.ts` and call it from `getTransportForOrigin` and `getUnverifiedTransportForOrigin` to throw when `isSecureContext` is false in browsers.
  - Added regression tests in `packages/tinfoil/test/encrypted-body-fetch.test.ts` to ensure both verified and unverified paths reject in insecure browser contexts.

<sup>Written for commit 05b78cac53a0f57c40bed7d6ee3774a25486096e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

