### PR TITLE
Harden attestation-bundle URL and proxy request handling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,11 @@
+# Agent Notes
+
+## TLS pinning reviews
+
+- Treat TLS pinning as an HTTPS-only property. Plain `http://` requests are not attested TLS connections and should not be reported as certificate-pinning bypasses; only report them when a code path that promises HTTPS fails to reject plaintext.
+- A real TLS pinning bypass is an HTTPS request that can complete without the peer certificate public key matching the attested TLS public-key fingerprint.
+- Review proxy and redirect behavior carefully, but distinguish fail-closed behavior from bypasses.
+
+## EHBP bundle reviews
+
+- EHBP request-body security is bound to the attested HPKE key. The bundled enclave certificate carries domain, HPKE, and attestation-hash bindings; it is not expected to be chain-trusted or to prove the attested TLS public key in EHBP mode.

--- a/packages/tinfoil/package.json
+++ b/packages/tinfoil/package.json
@@ -29,7 +29,7 @@
     "build": "tsc",
     "test": "vitest run",
     "test:integration": "RUN_TINFOIL_INTEGRATION=true npm test",
-    "test:bun": "bun test ./test/bun-compat.bun.ts",
+    "test:bun": "bun test --timeout 30000 ./test/bun-compat.bun.ts",
     "test:bun:integration": "RUN_TINFOIL_INTEGRATION=true bun test ./test/integration.bun.ts",
     "test:browser": "vitest run --config vite.config.browser.ts",
     "test:browser:integration": "vitest run --config vite.config.browser-test.ts",

--- a/packages/tinfoil/src/atc.ts
+++ b/packages/tinfoil/src/atc.ts
@@ -1,6 +1,6 @@
 import { TINFOIL_CONFIG } from "./config.js";
 import type { AttestationBundle } from "./verifier.js";
-import { FetchError } from "./verifier.js";
+import { ConfigurationError, FetchError } from "./verifier.js";
 
 export interface FetchAttestationBundleOptions {
   atcBaseUrl?: string;
@@ -17,6 +17,11 @@ export interface FetchAttestationBundleOptions {
  */
 export async function fetchAttestationBundle(options: FetchAttestationBundleOptions = {}): Promise<AttestationBundle> {
   const baseUrl = options.atcBaseUrl ?? TINFOIL_CONFIG.ATC_BASE_URL;
+  // The bundle is the entire trust root; fetching it over plaintext would let an
+  // attacker substitute it (MITM).
+  if (!baseUrl.startsWith("https://")) {
+    throw new ConfigurationError(`attestation bundle URL must use HTTPS. Got: ${baseUrl}`);
+  }
   const url = `${baseUrl}/attestation`;
 
   const usePost = !!(options.enclaveURL || options.configRepo);

--- a/packages/tinfoil/src/encrypted-body-fetch.ts
+++ b/packages/tinfoil/src/encrypted-body-fetch.ts
@@ -97,8 +97,20 @@ export async function encryptedBodyRequest(
 const ENCLAVE_URL_HEADER = 'X-Tinfoil-Enclave-Url';
 
 export function createEncryptedBodyFetch(baseURL: string, hpkePublicKey: string, enclaveURL?: string): SecureTransport {
-  const baseOrigin = new URL(baseURL).origin;
+  const base = new URL(baseURL);
+  if (base.protocol !== 'https:') {
+    throw new ConfigurationError(`baseURL must use HTTPS. Got: ${baseURL}`);
+  }
+  const baseOrigin = base.origin;
   const needsEnclaveHeader = !!enclaveURL && new URL(enclaveURL).origin !== baseOrigin;
+
+  // Bind requests to the verified enclave and the configured proxy. EHBP only
+  // seals the body, so request headers (which may carry the API key) travel in
+  // plaintext; sending them to any other origin would leak them.
+  const allowedOrigins = new Set<string>([baseOrigin]);
+  if (enclaveURL) {
+    allowedOrigins.add(new URL(enclaveURL).origin);
+  }
 
   let transportPromise: Promise<Transport> | null = null;
 
@@ -113,6 +125,11 @@ export function createEncryptedBodyFetch(baseURL: string, hpkePublicKey: string,
     fetch: async (input: RequestInfo | URL, init?: RequestInit) => {
       const normalized = normalizeEncryptedBodyRequestArgs(input, init);
       const targetUrl = new URL(normalized.url, baseURL);
+      if (!allowedOrigins.has(targetUrl.origin)) {
+        throw new ConfigurationError(
+          `refusing to send request to ${targetUrl.origin}: this client is bound to the verified enclave/proxy`
+        );
+      }
 
       const headers = new Headers(normalized.init?.headers);
       if (needsEnclaveHeader) {

--- a/packages/tinfoil/src/secure-client.ts
+++ b/packages/tinfoil/src/secure-client.ts
@@ -133,6 +133,19 @@ export class SecureClient {
     if (options.enclaveURL && !options.enclaveURL.startsWith("https://")) {
       throw new ConfigurationError(`enclaveURL must use HTTPS. Got: ${options.enclaveURL}`);
     }
+    // A proxy base URL and the attestation bundle URL both carry security-critical
+    // traffic (plaintext headers and the entire trust root), so they must be HTTPS.
+    if (options.baseURL && !options.baseURL.startsWith("https://")) {
+      throw new ConfigurationError(`baseURL must use HTTPS. Got: ${options.baseURL}`);
+    }
+    if (options.attestationBundleURL && !options.attestationBundleURL.startsWith("https://")) {
+      throw new ConfigurationError(`attestationBundleURL must use HTTPS. Got: ${options.attestationBundleURL}`);
+    }
+    // Routing through a proxy base URL relies on EHBP sealing the body to the
+    // enclave; TLS certificate pinning would reject the proxy's certificate.
+    if (options.baseURL && options.transport === 'tls') {
+      throw new ConfigurationError("baseURL is only supported with the 'ehbp' transport");
+    }
     if (options.configRepo && !options.enclaveURL) {
       throw new ConfigurationError("configRepo requires enclaveURL — without it, ATC always uses the default router repo.");
     } else if (options.enclaveURL && !options.configRepo) {

--- a/packages/tinfoil/src/secure-client.ts
+++ b/packages/tinfoil/src/secure-client.ts
@@ -130,15 +130,18 @@ export class SecureClient {
   private resolvedBaseURL?: string;
 
   constructor(options: SecureClientOptions = {}) {
-    if (options.enclaveURL && !options.enclaveURL.startsWith("https://")) {
+    // Validate every provided URL, including the empty string: URL resolution
+    // keeps "" (via ??) rather than falling back, so an unguarded empty value
+    // would surface later as a confusing "Invalid URL" instead of a clear error.
+    if (options.enclaveURL !== undefined && !options.enclaveURL.startsWith("https://")) {
       throw new ConfigurationError(`enclaveURL must use HTTPS. Got: ${options.enclaveURL}`);
     }
     // A proxy base URL and the attestation bundle URL both carry security-critical
     // traffic (plaintext headers and the entire trust root), so they must be HTTPS.
-    if (options.baseURL && !options.baseURL.startsWith("https://")) {
+    if (options.baseURL !== undefined && !options.baseURL.startsWith("https://")) {
       throw new ConfigurationError(`baseURL must use HTTPS. Got: ${options.baseURL}`);
     }
-    if (options.attestationBundleURL && !options.attestationBundleURL.startsWith("https://")) {
+    if (options.attestationBundleURL !== undefined && !options.attestationBundleURL.startsWith("https://")) {
       throw new ConfigurationError(`attestationBundleURL must use HTTPS. Got: ${options.attestationBundleURL}`);
     }
     // Routing through a proxy base URL relies on EHBP sealing the body to the

--- a/packages/tinfoil/test/atc.test.ts
+++ b/packages/tinfoil/test/atc.test.ts
@@ -93,6 +93,14 @@ describe("ATC API", () => {
 
       await expect(fetchAttestationBundle({ atcBaseUrl: "https://invalid.example.com" })).rejects.toThrow();
     });
+
+    it("should reject a non-HTTPS ATC URL", async () => {
+      const { fetchAttestationBundle } = await import("../src/atc");
+
+      await expect(fetchAttestationBundle({ atcBaseUrl: "http://atc.example.com" })).rejects.toThrow(
+        /must use HTTPS/
+      );
+    });
   });
 
   describe("fetchRouter", () => {

--- a/packages/tinfoil/test/encrypted-body-fetch.test.ts
+++ b/packages/tinfoil/test/encrypted-body-fetch.test.ts
@@ -184,6 +184,61 @@ describe("encrypted-body-fetch", () => {
       expect(typeof transport.getSessionRecoveryToken).toBe("function");
     });
 
+    it("rejects a non-HTTPS baseURL", () => {
+      expect(() => createEncryptedBodyFetch("http://api.example.com", "mockkey123")).toThrow(
+        /baseURL must use HTTPS/
+      );
+    });
+
+    it("refuses requests to an origin outside the enclave/proxy", async () => {
+      const transport = createEncryptedBodyFetch("https://api.example.com", "mockkey123");
+      await expect(transport.fetch("https://evil.example.com/steal")).rejects.toThrow(
+        /refusing to send request/
+      );
+    });
+
+    it("allows requests to the baseURL origin", async () => {
+      const serverIdentity = await Identity.generate();
+      const keyHex = await serverIdentity.getPublicKeyHex();
+
+      let apiRequestMade = false;
+      const originalFetch = globalThis.fetch;
+      globalThis.fetch = vi.fn(async (input: RequestInfo | URL) => {
+        const url = input instanceof Request ? input.url : input.toString();
+        if (url.includes("api.example.com")) apiRequestMade = true;
+        return new Response("ok");
+      }) as typeof fetch;
+
+      try {
+        const transport = createEncryptedBodyFetch("https://api.example.com", keyHex);
+        await transport.fetch("/test");
+        expect(apiRequestMade).toBe(true);
+      } finally {
+        globalThis.fetch = originalFetch;
+      }
+    });
+
+    it("allows requests to the enclave origin when routing through a proxy", async () => {
+      const serverIdentity = await Identity.generate();
+      const keyHex = await serverIdentity.getPublicKeyHex();
+
+      const originalFetch = globalThis.fetch;
+      globalThis.fetch = vi.fn(async () => new Response("ok")) as typeof fetch;
+
+      try {
+        const transport = createEncryptedBodyFetch(
+          "https://proxy.example.com",
+          keyHex,
+          "https://enclave.example.com"
+        );
+        await expect(
+          transport.fetch("https://enclave.example.com/test")
+        ).resolves.toBeInstanceOf(Response);
+      } finally {
+        globalThis.fetch = originalFetch;
+      }
+    });
+
   });
 
   describe("createUnverifiedEncryptedBodyFetch", () => {

--- a/packages/tinfoil/test/secure-client.test.ts
+++ b/packages/tinfoil/test/secure-client.test.ts
@@ -471,6 +471,30 @@ describe("SecureClient", () => {
         new SecureClient({ baseURL: "https://proxy.example.com", transport: "tls" });
       }).toThrow("baseURL is only supported with the 'ehbp' transport");
     });
+
+    it("should throw ConfigurationError for an empty baseURL instead of failing later", async () => {
+      const { SecureClient } = await import("../src/secure-client");
+
+      expect(() => {
+        new SecureClient({ baseURL: "" });
+      }).toThrow("baseURL must use HTTPS");
+    });
+
+    it("should throw ConfigurationError for an empty enclaveURL", async () => {
+      const { SecureClient } = await import("../src/secure-client");
+
+      expect(() => {
+        new SecureClient({ enclaveURL: "" });
+      }).toThrow("enclaveURL must use HTTPS");
+    });
+
+    it("should throw ConfigurationError for an empty attestationBundleURL", async () => {
+      const { SecureClient } = await import("../src/secure-client");
+
+      expect(() => {
+        new SecureClient({ attestationBundleURL: "" });
+      }).toThrow("attestationBundleURL must use HTTPS");
+    });
   });
 
   describe("attestation bundle paths", () => {

--- a/packages/tinfoil/test/secure-client.test.ts
+++ b/packages/tinfoil/test/secure-client.test.ts
@@ -447,6 +447,30 @@ describe("SecureClient", () => {
       expect(consoleSpy).not.toHaveBeenCalled();
       consoleSpy.mockRestore();
     });
+
+    it("should throw ConfigurationError when baseURL is not HTTPS", async () => {
+      const { SecureClient } = await import("../src/secure-client");
+
+      expect(() => {
+        new SecureClient({ baseURL: "http://proxy.example.com" });
+      }).toThrow("baseURL must use HTTPS");
+    });
+
+    it("should throw ConfigurationError when attestationBundleURL is not HTTPS", async () => {
+      const { SecureClient } = await import("../src/secure-client");
+
+      expect(() => {
+        new SecureClient({ attestationBundleURL: "http://atc.example.com" });
+      }).toThrow("attestationBundleURL must use HTTPS");
+    });
+
+    it("should throw ConfigurationError when baseURL is combined with the tls transport", async () => {
+      const { SecureClient } = await import("../src/secure-client");
+
+      expect(() => {
+        new SecureClient({ baseURL: "https://proxy.example.com", transport: "tls" });
+      }).toThrow("baseURL is only supported with the 'ehbp' transport");
+    });
   });
 
   describe("attestation bundle paths", () => {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Hardened transport and attestation fetching: enforce HTTPS for trust-critical URLs (`baseURL`, `attestationBundleURL`, `enclaveURL`), bind encrypted-body requests to enclave/proxy origins, and reject blank URL options early. Documented TLS pinning scope and EHBP bundle behavior to guide reviews.

- **Bug Fixes**
  - ATC: enforce HTTPS for the attestation bundle URL; fail on HTTP.
  - Encrypted body fetch: require HTTPS for `baseURL`; refuse requests outside enclave/proxy origins.
  - `SecureClient`: require HTTPS for all URLs; disallow `baseURL` with `transport: 'tls'`; reject empty URL options early.
  - Tests: add coverage for guards; increase `test:bun` timeout to 30s for live TLS.

<sup>Written for commit e4dbba5c7ec4b914caee48df4a43f88f1312536b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-js/pull/169?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

