### PR TITLE
WS: Refetch attestation on TLS key fail

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4175,12 +4175,12 @@
       }
     },
     "packages/tinfoil": {
-      "version": "1.1.5",
+      "version": "1.1.6",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@ai-sdk/openai-compatible": "^2.0.41",
         "@freedomofpress/sigstore-browser": "^0.1.13",
-        "@tinfoilsh/verifier": "1.1.5",
+        "@tinfoilsh/verifier": "1.1.6",
         "@types/ws": "^8.18.1",
         "ehbp": "^0.2.0",
         "openai": "^6.34.0",
@@ -4420,7 +4420,7 @@
     },
     "packages/verifier": {
       "name": "@tinfoilsh/verifier",
-      "version": "1.1.5",
+      "version": "1.1.6",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@freedomofpress/crypto-browser": "^0.1.7",

--- a/packages/tinfoil/package.json
+++ b/packages/tinfoil/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tinfoil",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "description": "Tinfoil secure OpenAI client wrapper",
   "type": "module",
   "main": "dist/index.js",
@@ -63,7 +63,7 @@
   "dependencies": {
     "@ai-sdk/openai-compatible": "^2.0.41",
     "@freedomofpress/sigstore-browser": "^0.1.13",
-    "@tinfoilsh/verifier": "1.1.5",
+    "@tinfoilsh/verifier": "1.1.6",
     "@types/ws": "^8.18.1",
     "ehbp": "^0.2.0",
     "openai": "^6.34.0",

--- a/packages/tinfoil/src/secure-client.ts
+++ b/packages/tinfoil/src/secure-client.ts
@@ -401,7 +401,8 @@ export class SecureClient {
    * Node.js only. Not supported with a proxy `baseURL`.
    *
    * The returned socket is a standard `ws` WebSocket in the CONNECTING state;
-   * pinning failures surface as an `error` event.
+   * pinning failures surface as an `error` event. A pin failure drops the cached
+   * attestation, so the next createWebSocket() re-attests and recovers.
    *
    * @param path - Path (and query) relative to the enclave URL, e.g.
    *   `/v1/realtime?model=voxtral-mini-4b-realtime`
@@ -435,6 +436,16 @@ export class SecureClient {
     }
 
     const { createPinnedWebSocket } = await import("./pinned-ws.js");
-    return createPinnedWebSocket(target.toString(), fingerprint, options);
+    const socket = await createPinnedWebSocket(target.toString(), fingerprint, options);
+
+    // The TLS key is cached only for performance; on a pin failure (e.g. the enclave
+    // rotated its key) drop it so the next call re-attests against the current key.
+    socket.once("error", (err: Error) => {
+      if (err instanceof AttestationError) {
+        this.reset();
+      }
+    });
+
+    return socket;
   }
 }

--- a/packages/tinfoil/test/secure-client.websocket.test.ts
+++ b/packages/tinfoil/test/secure-client.websocket.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { EventEmitter } from "events";
 
 const MOCK_MEASUREMENT_TYPE = "https://tinfoil.sh/predicate/sev-snp-guest/v2";
 const MOCK_FINGERPRINT = "ab".repeat(32);
@@ -42,7 +43,7 @@ vi.mock("../src/atc.js", () => ({
   fetchRouter: vi.fn(async () => "enclave.example.com"),
 }));
 
-const createPinnedWebSocketMock = vi.fn(async () => ({ mock: "socket" }));
+const createPinnedWebSocketMock = vi.fn(async () => new EventEmitter());
 const pinnedWsClientOptionsMock = vi.fn(async () => ({
   rejectUnauthorized: true,
 }));
@@ -53,10 +54,12 @@ vi.mock("../src/pinned-ws.js", () => ({
 }));
 
 import { SecureClient } from "../src/secure-client.js";
-import { ConfigurationError } from "../src/verifier.js";
+import { ConfigurationError, AttestationError } from "../src/verifier.js";
+import { fetchAttestationBundle } from "../src/atc.js";
 
 beforeEach(() => {
   createPinnedWebSocketMock.mockClear();
+  vi.mocked(fetchAttestationBundle).mockClear();
 });
 
 describe("SecureClient.createWebSocket", () => {
@@ -105,6 +108,35 @@ describe("SecureClient.createWebSocket", () => {
       client.createWebSocket("wss://evil.example.com/v1/realtime"),
     ).rejects.toThrow(/bound to the verified enclave/);
     expect(createPinnedWebSocketMock).not.toHaveBeenCalled();
+  });
+
+  it("re-attests after a TLS pin failure", async () => {
+    const client = new SecureClient();
+    const socket = await client.createWebSocket("/v1/realtime?model=test-model");
+    expect(fetchAttestationBundle).toHaveBeenCalledTimes(1);
+
+    // A stale pin (enclave rotated its TLS key) surfaces as an `error` event;
+    // the client should drop its cached attestation so the next call re-attests.
+    socket.emit(
+      "error",
+      new AttestationError(
+        "TLS pinning failed: Server certificate public key does not match the attested key",
+      ),
+    );
+
+    await client.createWebSocket("/v1/realtime?model=test-model");
+    expect(fetchAttestationBundle).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps the cached attestation on an unrelated socket error", async () => {
+    const client = new SecureClient();
+    const socket = await client.createWebSocket("/v1/realtime?model=test-model");
+    expect(fetchAttestationBundle).toHaveBeenCalledTimes(1);
+
+    socket.emit("error", new Error("ECONNRESET"));
+
+    await client.createWebSocket("/v1/realtime?model=test-model");
+    expect(fetchAttestationBundle).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/packages/verifier/package.json
+++ b/packages/verifier/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tinfoilsh/verifier",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "description": "AMD SEV-SNP attestation verifier for Node.js and browsers",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
The TLS key is cached for performance reasons, instead of refetching attestation each time. If it fails, then we need to refetch attestation. Before the client never refetched



