### PR TITLE
chore: bump version to 1.1.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4175,12 +4175,12 @@
       }
     },
     "packages/tinfoil": {
-      "version": "1.1.6",
+      "version": "1.1.7",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@ai-sdk/openai-compatible": "^2.0.41",
         "@freedomofpress/sigstore-browser": "^0.1.13",
-        "@tinfoilsh/verifier": "1.1.6",
+        "@tinfoilsh/verifier": "1.1.7",
         "@types/ws": "^8.18.1",
         "ehbp": "^0.2.0",
         "openai": "^6.34.0",
@@ -4420,7 +4420,7 @@
     },
     "packages/verifier": {
       "name": "@tinfoilsh/verifier",
-      "version": "1.1.6",
+      "version": "1.1.7",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@freedomofpress/crypto-browser": "^0.1.7",

--- a/packages/tinfoil/package.json
+++ b/packages/tinfoil/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tinfoil",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "description": "Tinfoil secure OpenAI client wrapper",
   "type": "module",
   "main": "dist/index.js",
@@ -63,7 +63,7 @@
   "dependencies": {
     "@ai-sdk/openai-compatible": "^2.0.41",
     "@freedomofpress/sigstore-browser": "^0.1.13",
-    "@tinfoilsh/verifier": "1.1.6",
+    "@tinfoilsh/verifier": "1.1.7",
     "@types/ws": "^8.18.1",
     "ehbp": "^0.2.0",
     "openai": "^6.34.0",

--- a/packages/verifier/package.json
+++ b/packages/verifier/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tinfoilsh/verifier",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "description": "AMD SEV-SNP attestation verifier for Node.js and browsers",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Bumps `tinfoil` and `@tinfoilsh/verifier` to 1.1.7 and updates `tinfoil` to depend on `@tinfoilsh/verifier` 1.1.7 to keep versions in sync.

<sup>Written for commit 31fc3c7425bf43779cacb2247c9d5646db5e9681. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-js/pull/174?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

