### PR TITLE
sigstore: reject legacy x509CertificateChain bundle format (SPEC §5.2)

### DIFF
--- a/packages/verifier/src/sigstore.ts
+++ b/packages/verifier/src/sigstore.ts
@@ -57,6 +57,16 @@ export async function verifySigstoreBundle(
 
     const bundle = bundleJson as any;
 
+    // SPEC §5.2: only the v0.3 single-certificate bundle layout is accepted.
+    // Reject the legacy v0.1/v0.2 layout, which conveys the signing cert under
+    // verificationMaterial.x509CertificateChain (and may also carry CA certs —
+    // a misuse vector the v0.3 single-certificate form avoids).
+    if (bundle?.verificationMaterial?.x509CertificateChain) {
+      throw new AttestationError(
+        'Legacy x509CertificateChain bundle format is not supported; only the v0.3 single-certificate format is accepted'
+      );
+    }
+
     // Create policy for GitHub Actions certificate identity
     const policy = new AllOf([
       new OIDCIssuer(GITHUB_OIDC_ISSUER),


### PR DESCRIPTION
The verifier accepted the legacy v0.1/v0.2 bundle layout (signing cert under verificationMaterial.x509CertificateChain) because @freedomofpress/sigstore- browser parses it. Per SPEC §5.2 the legacy layout MUST be rejected: tinfoil only produces v0.3 bundles.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reject legacy Sigstore bundle format (`verificationMaterial.x509CertificateChain`) per SPEC §5.2. `verifySigstoreBundle` now errors on v0.1/v0.2 bundles and only accepts v0.3 single-certificate bundles, preventing CA-chain misuse and matching tinfoil-go/-rs/-py.

<sup>Written for commit bdb4d279a82f9bfee3a00348fe768163d7059c31. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-js/pull/175?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

