### PR TITLE
sigstore: reject in-toto statements with unknown top-level fields (SPEC §5.4)

### DIFF
--- a/packages/verifier/src/sigstore.ts
+++ b/packages/verifier/src/sigstore.ts
@@ -76,6 +76,19 @@ export async function verifySigstoreBundle(
       throw new AttestationError(`Unsupported Sigstore payload type: "${payloadType}". Only in-toto statements (application/vnd.in-toto+json) are supported`);
     }
 
+    // SPEC §5.4: the in-toto statement MUST contain only the recognized
+    // top-level fields (_type, subject, predicateType, predicate); reject
+    // unknown ones, matching tinfoil-go/-rs/-py.
+    {
+      const allowed = new Set(['_type', 'subject', 'predicateType', 'predicate']);
+      const extra = Object.keys(payload).filter((k) => !allowed.has(k));
+      if (extra.length > 0) {
+        throw new AttestationError(
+          `In-toto statement has unknown top-level field(s): ${extra.sort().join(', ')}`
+        );
+      }
+    }
+
     const predicateType = payload.predicateType as PredicateType;
     const predicateFields = payload.predicate;
 


### PR DESCRIPTION
@freedomofpress/sigstore-browser tolerates unknown top-level fields in the in-toto statement. Per SPEC §5.4 the statement MUST contain only the recognized fields (_type, subject, predicateType, predicate); verifySigstoreBundle now rejects any unknown top-level field, matching tinfoil-go/-rs/-py. Tinfoil produces canonical statements, so an unknown field is non-canonical.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reject in-toto statements with unknown top-level fields per SPEC §5.4 in `verifySigstoreBundle`. This aligns `@freedomofpress/sigstore-browser` with tinfoil implementations and avoids accepting non-canonical statements.

- **Bug Fixes**
  - Allow only `_type`, `subject`, `predicateType`, and `predicate`; any extra top-level keys throw an `AttestationError` listing the unknown fields.

<sup>Written for commit f34e87af3eaa94b2409e53fb1848aa30c3824d24. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-js/pull/176?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

