### PR TITLE
feat: provision user_cache_secret for per-user prompt cache scoping

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,36 @@ const transport = new DefaultChatTransport({
 
 See the [Vercel AI Browser SDK Example](packages/tinfoil/examples/ai-sdk-react/) for complete React patterns with `useChat`, context providers, and error handling.
 
+## Prompt Cache Scoping
+
+The inference router partitions its prompt cache per API identity, so your cached prompts are never observable by other tenants. Within your tenant, the SDK scopes caching further with a `user_cache_secret`: requests carrying the same secret share cached prompt prefixes, requests carrying different secrets cannot observe each other's cache timing. The secret never reaches the model — the router consumes it to derive the cache namespace and strips it from the request.
+
+By default the SDK generates a random secret and persists it at `~/.tinfoil/user_cache_secret` (mode `0600`, shared with the other Tinfoil SDKs on the same machine), so caching just works with per-machine scoping. You can control it explicitly:
+
+```typescript
+// Pin the secret for this client (e.g. one stable value per end user).
+// SecureClient and createTinfoilAI accept the same option.
+const client = new TinfoilAI({ userCacheSecret: secret });
+
+// Or provision it via the environment (Node.js)
+//   TINFOIL_USER_CACHE_SECRET=<secret>   use this value
+//   TINFOIL_USER_CACHE_SECRET=           (set but empty) disable: tenant-wide caching
+
+// Servers that hold many end users' conversations should scope per request;
+// a `user_cache_secret` field set in the request body always wins over the
+// client-level secret:
+const completion = await client.chat.completions.create({
+  model: "llama3-3-70b",
+  messages: [{ role: "user", content: "Hello!" }],
+  user_cache_secret: perUserSecret,
+} as TinfoilAI.Chat.ChatCompletionCreateParams);
+
+// Opt out entirely (tenant-wide caching, no file written)
+const optedOut = new TinfoilAI({ userCacheSecret: "" });
+```
+
+If the secret cannot be persisted (no home directory, read-only filesystem, or a browser — browsers have no filesystem), the SDK falls back to an in-memory secret and warns once: cache continuity then resets on every restart. Containerized deployments should set `TINFOIL_USER_CACHE_SECRET` explicitly — one value per end user if requests are per-user, or empty to keep tenant-wide caching across replicas.
+
 ## How Verification Works
 
 When you create a client, the SDK **automatically**:

--- a/packages/tinfoil/package.json
+++ b/packages/tinfoil/package.json
@@ -11,7 +11,8 @@
     "./dist/pinned-tls-fetch.js": "./dist/pinned-tls-fetch.browser.js",
     "./dist/pinned-ws.js": "./dist/pinned-ws.browser.js",
     "./dist/realtime.js": "./dist/realtime.browser.js",
-    "./dist/unsafe.js": "./dist/unsafe.browser.js"
+    "./dist/unsafe.js": "./dist/unsafe.browser.js",
+    "./dist/user-cache-secret-store.js": "./dist/user-cache-secret-store.browser.js"
   },
   "exports": {
     ".": {

--- a/packages/tinfoil/package.json
+++ b/packages/tinfoil/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tinfoil",
-  "version": "1.1.8",
+  "version": "1.1.9",
   "description": "Tinfoil secure OpenAI client wrapper",
   "type": "module",
   "main": "dist/index.js",
@@ -64,7 +64,7 @@
   "dependencies": {
     "@ai-sdk/openai-compatible": "^2.0.41",
     "@freedomofpress/sigstore-browser": "^0.1.13",
-    "@tinfoilsh/verifier": "1.1.8",
+    "@tinfoilsh/verifier": "1.1.9",
     "@types/ws": "^8.18.1",
     "ehbp": "^0.2.0",
     "openai": "^6.34.0",

--- a/packages/tinfoil/src/ai-sdk-provider.ts
+++ b/packages/tinfoil/src/ai-sdk-provider.ts
@@ -18,6 +18,14 @@ export interface CreateTinfoilAIOptions {
 
   /** URL to fetch the attestation bundle from. */
   attestationBundleURL?: string;
+
+  /**
+   * Secret scoping the router's prompt cache for this provider's requests.
+   * Defaults to the TINFOIL_USER_CACHE_SECRET environment variable, otherwise
+   * to a generated secret persisted at `~/.tinfoil/user_cache_secret`. Pass
+   * an empty string to disable prompt-cache scoping (tenant-wide caching).
+   */
+  userCacheSecret?: string;
 }
 
 /**
@@ -64,6 +72,7 @@ export async function createTinfoilAI(apiKey?: string, options: CreateTinfoilAIO
     baseURL: options.baseURL,
     configRepo: options.configRepo,
     attestationBundleURL: options.attestationBundleURL,
+    userCacheSecret: options.userCacheSecret,
   });
 
   await secureClient.ready();

--- a/packages/tinfoil/src/encrypted-body-fetch.ts
+++ b/packages/tinfoil/src/encrypted-body-fetch.ts
@@ -1,5 +1,6 @@
 import { Identity, Transport, PROTOCOL, type SessionRecoveryToken } from "ehbp";
 import { ConfigurationError, FetchError } from "./verifier.js";
+import { injectUserCacheSecretIntoRequestInit } from "./user-cache-secret.js";
 
 export type { SessionRecoveryToken } from "ehbp";
 export { decryptResponseWithToken } from "ehbp";
@@ -92,7 +93,7 @@ export async function encryptedBodyRequest(
 
 const ENCLAVE_URL_HEADER = 'X-Tinfoil-Enclave-Url';
 
-export function createEncryptedBodyFetch(baseURL: string, hpkePublicKey: string, enclaveURL?: string): SecureTransport {
+export function createEncryptedBodyFetch(baseURL: string, hpkePublicKey: string, enclaveURL?: string, userCacheSecret: string = ""): SecureTransport {
   const base = new URL(baseURL);
   const baseOrigin = base.origin;
   const needsEnclaveHeader = !!enclaveURL && new URL(enclaveURL).origin !== baseOrigin;
@@ -128,7 +129,14 @@ export function createEncryptedBodyFetch(baseURL: string, hpkePublicKey: string,
       if (needsEnclaveHeader) {
         headers.set(ENCLAVE_URL_HEADER, enclaveURL!);
       }
-      const initWithHeader = { ...normalized.init, headers };
+      // The prompt-cache scoping field is added here — inside the origin
+      // guard and before the EHBP transport seals the body — so it is
+      // encrypted with the rest of the request.
+      const initWithHeader = await injectUserCacheSecretIntoRequestInit(
+        { ...normalized.init, headers },
+        targetUrl.pathname,
+        userCacheSecret,
+      );
 
       const transportInstance = await getOrCreateTransport();
       return encryptedBodyRequest(targetUrl.toString(), hpkePublicKey, initWithHeader, transportInstance);

--- a/packages/tinfoil/src/secure-client.ts
+++ b/packages/tinfoil/src/secure-client.ts
@@ -3,6 +3,7 @@ import { Verifier, ConfigurationError, FetchError, AttestationError, type Verifi
 import type { AttestationBundle } from "./verifier.js";
 import { TINFOIL_CONFIG } from "./config.js";
 import { createSecureFetch } from "./secure-fetch.js";
+import { resolveUserCacheSecret } from "./user-cache-secret.js";
 import { fetchAttestationBundle } from "./atc.js";
 import type { SecureTransport, SessionRecoveryToken } from "./encrypted-body-fetch.js";
 import type { SecureWebSocketOptions } from "./pinned-ws.js";
@@ -56,6 +57,22 @@ export interface SecureClientOptions {
 
   /** URL to fetch the attestation bundle from. */
   attestationBundleURL?: string;
+
+  /**
+   * Secret scoping the router's prompt cache for this client's requests.
+   * Requests carrying the same secret share cached prompt prefixes; requests
+   * carrying different secrets cannot observe each other's cache timing. The
+   * router consumes the secret to derive the cache namespace and strips it —
+   * it never reaches the model.
+   *
+   * Defaults to the TINFOIL_USER_CACHE_SECRET environment variable when set,
+   * otherwise to a generated secret persisted at `~/.tinfoil/user_cache_secret`
+   * (shared with the other Tinfoil SDKs on the same machine). Pass an empty
+   * string to disable prompt-cache scoping entirely (tenant-wide caching).
+   * A `user_cache_secret` field already present in a request body always
+   * wins over this option.
+   */
+  userCacheSecret?: string;
 }
 
 function createPendingVerificationDocument(configRepo: string): VerificationDocument {
@@ -125,6 +142,7 @@ export class SecureClient {
     readonly configRepo: string;
     readonly transport: TransportMode;
     readonly attestationBundleURL?: string;
+    readonly userCacheSecret?: string;
   };
 
   // --- Derived state (cleared on reset) ---
@@ -170,6 +188,7 @@ export class SecureClient {
       configRepo: options.configRepo ?? TINFOIL_CONFIG.DEFAULT_ROUTER_REPO,
       transport: options.transport || 'ehbp',
       attestationBundleURL: options.attestationBundleURL,
+      userCacheSecret: options.userCacheSecret,
     };
     this.verificationDocument = createPendingVerificationDocument(this.config.configRepo);
   }
@@ -309,11 +328,17 @@ export class SecureClient {
   }
 
   private async createTransport(hpkePublicKey?: string, tlsPublicKeyFingerprint?: string): Promise<SecureTransport> {
+    // The prompt-cache scoping secret: the userCacheSecret option wins, then
+    // the TINFOIL_USER_CACHE_SECRET environment variable, then the secret
+    // persisted at ~/.tinfoil/user_cache_secret (generated on first use).
+    // Empty means disabled; resolution never throws.
+    const userCacheSecret = await resolveUserCacheSecret(this.config.userCacheSecret);
+
     if (this.config.transport === 'tls') {
-      return await createSecureFetch(this.resolvedBaseURL!, undefined, tlsPublicKeyFingerprint, this.resolvedEnclaveURL);
+      return await createSecureFetch(this.resolvedBaseURL!, undefined, tlsPublicKeyFingerprint, this.resolvedEnclaveURL, userCacheSecret);
     }
 
-    return await createSecureFetch(this.resolvedBaseURL!, hpkePublicKey, undefined, this.resolvedEnclaveURL);
+    return await createSecureFetch(this.resolvedBaseURL!, hpkePublicKey, undefined, this.resolvedEnclaveURL, userCacheSecret);
   }
 
   /**

--- a/packages/tinfoil/src/secure-fetch.ts
+++ b/packages/tinfoil/src/secure-fetch.ts
@@ -1,6 +1,7 @@
 import { isRealBrowser } from "./env.js";
 import { ConfigurationError } from "./verifier.js";
 import { createEncryptedBodyFetch, type SecureTransport } from "./encrypted-body-fetch.js";
+import { withUserCacheSecret } from "./user-cache-secret.js";
 
 /**
  * Creates a secure fetch function with either HPKE encryption or TLS pinning.
@@ -9,16 +10,21 @@ import { createEncryptedBodyFetch, type SecureTransport } from "./encrypted-body
  * - In browsers: Only HPKE encryption is supported (requires hpkePublicKey)
  * - In Node.js/Bun: Also supports TLS certificate pinning when configured
  *
+ * A non-empty userCacheSecret is injected into eligible request bodies inside
+ * the sealing boundary (EHBP body encryption or the pinned TLS connection),
+ * so the secret never travels outside the protected channel.
+ *
  * The pinned-tls-fetch import is dynamic to keep Node.js-only code out of browser bundles.
  */
 export async function createSecureFetch(
   baseURL: string,
   hpkePublicKey?: string,
   tlsPublicKeyFingerprint?: string,
-  enclaveURL?: string
+  enclaveURL?: string,
+  userCacheSecret: string = ""
 ): Promise<SecureTransport> {
   if (hpkePublicKey) {
-    return createEncryptedBodyFetch(baseURL, hpkePublicKey, enclaveURL);
+    return createEncryptedBodyFetch(baseURL, hpkePublicKey, enclaveURL, userCacheSecret);
   }
 
   if (isRealBrowser()) {
@@ -38,7 +44,9 @@ export async function createSecureFetch(
   const { createPinnedTlsFetch } = await import("./pinned-tls-fetch.js");
   const pinnedFetch = await createPinnedTlsFetch(baseURL, tlsPublicKeyFingerprint);
   return {
-    fetch: pinnedFetch,
+    // The cache-secret layer wraps the pinned fetch, so the field it injects
+    // only ever travels over the connection pinned to the attested key.
+    fetch: withUserCacheSecret(pinnedFetch, baseURL, userCacheSecret),
     async getSessionRecoveryToken() {
       throw new Error('Session recovery tokens are only available in EHBP transport mode');
     },

--- a/packages/tinfoil/src/tinfoil-ai.ts
+++ b/packages/tinfoil/src/tinfoil-ai.ts
@@ -96,7 +96,17 @@ export interface TinfoilAIOptions {
 
   /** URL to fetch the attestation bundle from. */
   attestationBundleURL?: string;
-  
+
+  /**
+   * Secret scoping the router's prompt cache for this client's requests
+   * (e.g. one stable value per end user). Defaults to the
+   * TINFOIL_USER_CACHE_SECRET environment variable, otherwise to a generated
+   * secret persisted at `~/.tinfoil/user_cache_secret`. Pass an empty string
+   * to disable prompt-cache scoping (tenant-wide caching). A
+   * `user_cache_secret` field set in a request body always wins.
+   */
+  userCacheSecret?: string;
+
   /** Additional OpenAI client options (passed through to underlying client) */
   [key: string]: any;
 }
@@ -155,6 +165,7 @@ export class TinfoilAI {
       configRepo: options.configRepo,
       transport: options.transport,
       attestationBundleURL: options.attestationBundleURL,
+      userCacheSecret: options.userCacheSecret,
     });
   }
 

--- a/packages/tinfoil/src/user-cache-secret-store.browser.ts
+++ b/packages/tinfoil/src/user-cache-secret-store.browser.ts
@@ -1,0 +1,9 @@
+/**
+ * Browser build of the user-cache-secret store. Browsers have no filesystem
+ * to persist the secret in, so resolution always falls back to the
+ * process-lifetime in-memory secret.
+ */
+
+export function loadOrPersistUserCacheSecret(_generateSecret: () => string): string | null {
+  return null;
+}

--- a/packages/tinfoil/src/user-cache-secret-store.ts
+++ b/packages/tinfoil/src/user-cache-secret-store.ts
@@ -1,0 +1,180 @@
+import {
+  closeSync,
+  constants,
+  fstatSync,
+  linkSync,
+  lstatSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { randomUUID } from "node:crypto";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+/**
+ * Node.js persistence for the user cache secret. The other Tinfoil SDKs use
+ * the same file, so one machine gets one cache namespace across tools. The
+ * browser build swaps this module for a stub (see package.json's `browser`
+ * field) — browsers have no filesystem, so resolution falls back to the
+ * process-lifetime in-memory secret.
+ */
+
+/** Directory under the home directory holding the secret file (mode 0700). */
+export const USER_CACHE_SECRET_DIR_NAME = ".tinfoil";
+
+/** Secret file name under the directory (mode 0600). */
+export const USER_CACHE_SECRET_FILE_NAME = "user_cache_secret";
+
+const HAS_POSIX_PERMISSIONS = process.platform !== "win32";
+
+function posixReadFlags(): number {
+  return constants.O_RDONLY | constants.O_NOFOLLOW | constants.O_NONBLOCK;
+}
+
+function trimPersistenceWhitespace(value: string): string {
+  return value.replace(/^\p{White_Space}+|\p{White_Space}+$/gu, "");
+}
+
+function isExpectedWindowsPath(
+  path: string,
+  expectedType: "directory" | "file",
+): boolean | undefined {
+  try {
+    const stats = lstatSync(path);
+    if (stats.isSymbolicLink()) {
+      return false;
+    }
+    return expectedType === "directory" ? stats.isDirectory() : stats.isFile();
+  } catch (err) {
+    return (err as { code?: string } | null)?.code === "ENOENT" ? undefined : false;
+  }
+}
+
+/** Reads the secret file, distinguishing a missing file from unusable state. */
+function readSecretFile(path: string): string | undefined | null {
+  let fd: number | undefined;
+  try {
+    if (!HAS_POSIX_PERMISSIONS) {
+      const pathState = isExpectedWindowsPath(path, "file");
+      if (pathState !== true) {
+        return pathState === undefined ? undefined : null;
+      }
+    }
+    fd = openSync(path, HAS_POSIX_PERMISSIONS ? posixReadFlags() : "r");
+    if (HAS_POSIX_PERMISSIONS) {
+      if (!fstatSync(fd).isFile()) {
+        return null;
+      }
+    }
+    let secret: string;
+    try {
+      secret = trimPersistenceWhitespace(
+        new TextDecoder("utf-8", { fatal: true }).decode(readFileSync(fd)),
+      );
+    } catch {
+      return null;
+    }
+    return secret === "" ? null : secret;
+  } catch (err) {
+    return (err as { code?: string } | null)?.code === "ENOENT" ? undefined : null;
+  } finally {
+    if (fd !== undefined) {
+      try {
+        closeSync(fd);
+      } catch {
+        // Best-effort cleanup after the read has completed.
+      }
+    }
+  }
+}
+
+/**
+ * Returns the secret persisted under the user's home directory, generating
+ * (via `generateSecret`) and persisting one on first use. Returns null when
+ * the home directory is unavailable or unwritable — the caller falls back to
+ * a process-lifetime in-memory secret. Never throws.
+ */
+export function loadOrPersistUserCacheSecret(generateSecret: () => string): string | null {
+  let home: string;
+  try {
+    home = homedir();
+  } catch {
+    return null;
+  }
+  if (!home) {
+    return null;
+  }
+  const dir = join(home, USER_CACHE_SECRET_DIR_NAME);
+  const path = join(dir, USER_CACHE_SECRET_FILE_NAME);
+
+  try {
+    if (!HAS_POSIX_PERMISSIONS && isExpectedWindowsPath(dir, "directory") === false) {
+      return null;
+    }
+    mkdirSync(dir, { recursive: true, mode: 0o700 });
+    if (HAS_POSIX_PERMISSIONS) {
+      let dirFd: number | undefined;
+      try {
+        dirFd = openSync(dir, posixReadFlags() | constants.O_DIRECTORY);
+        if (!fstatSync(dirFd).isDirectory()) {
+          return null;
+        }
+      } finally {
+        if (dirFd !== undefined) {
+          closeSync(dirFd);
+        }
+      }
+    } else if (isExpectedWindowsPath(dir, "directory") !== true) {
+      return null;
+    }
+  } catch {
+    return null;
+  }
+
+  const existing = readSecretFile(path);
+  if (existing === null) {
+    return null;
+  }
+  if (existing !== undefined) {
+    return existing;
+  }
+
+  const secret = generateSecret();
+  if (secret === "") {
+    // CSPRNG failure (the generator already warned): tenant-wide caching,
+    // nothing worth persisting.
+    return "";
+  }
+
+  const candidatePath = join(
+    dir,
+    `${USER_CACHE_SECRET_FILE_NAME}.${process.pid}.${randomUUID()}.tmp`,
+  );
+
+  try {
+    // A complete temporary file is linked directly to the destination.
+    // Hard-link creation is atomic, so concurrent first users either win or
+    // adopt the complete destination created by another process.
+    writeFileSync(candidatePath, secret, { encoding: "utf8", flag: "wx", mode: 0o600 });
+    try {
+      linkSync(candidatePath, path);
+    } catch (err) {
+      if ((err as { code?: string } | null)?.code !== "EEXIST") {
+        return null;
+      }
+    }
+    const persisted = readSecretFile(path);
+    return persisted ?? null;
+  } catch {
+    return null;
+  } finally {
+    try {
+      unlinkSync(candidatePath);
+    } catch {
+      // Best-effort cleanup: the candidate is never the persisted file.
+    }
+  }
+}

--- a/packages/tinfoil/src/user-cache-secret.ts
+++ b/packages/tinfoil/src/user-cache-secret.ts
@@ -1,0 +1,287 @@
+import { isRealBrowser } from "./env.js";
+
+/**
+ * `user_cache_secret` provisions the per-user prompt-cache secret defined by
+ * the secure prompt caching contract. The router derives the request's
+ * prefix-cache namespace from it: requests carrying the same secret (under
+ * the same API identity) share cached prompt prefixes, requests carrying
+ * different secrets cannot observe each other's cache timing. The secret
+ * itself is stripped by the router and never reaches the model.
+ *
+ * Resolution order, mirroring the other Tinfoil clients:
+ *
+ *  1. an explicit per-request `user_cache_secret` field in the body (never
+ *     overwritten here),
+ *  2. the `userCacheSecret` client option,
+ *  3. the TINFOIL_USER_CACHE_SECRET environment variable,
+ *  4. a generated secret persisted at ~/.tinfoil/user_cache_secret (0600),
+ *     shared with the other Tinfoil SDKs on the same machine. Runtimes
+ *     without a filesystem (browsers, edge runtimes) fall back to a
+ *     process-lifetime in-memory secret.
+ *
+ * Injection happens inside the secure transport — before the EHBP transport
+ * encrypts the body, or on the way into the TLS connection pinned to the
+ * attested key — so the secret is only ever visible to the verified enclave.
+ */
+
+/**
+ * The router-only request-body field. A non-empty string scopes the prompt
+ * cache to that secret; an absent or empty value leaves the request in the
+ * tenant-wide namespace.
+ */
+export const USER_CACHE_SECRET_FIELD = "user_cache_secret";
+
+/**
+ * Provisions the secret via the environment. Setting it to an empty string
+ * disables generation entirely (tenant-wide caching), which is the right
+ * call for pooled multi-user deployments that would otherwise mint a fresh
+ * namespace per container.
+ */
+export const USER_CACHE_SECRET_ENV = "TINFOIL_USER_CACHE_SECRET";
+
+/**
+ * The OpenAI-compatible endpoints whose bodies carry the field. Matched by
+ * path suffix with no /v1 prefix required, so custom base URLs
+ * (path-prefixed proxies or /v1-less roots) still qualify. Other endpoints
+ * (embeddings, audio, files) are excluded: their engines do not prefix-cache
+ * and may reject unknown fields.
+ */
+const USER_CACHE_SECRET_PATHS = [
+  "/chat/completions",
+  "/completions",
+  "/responses",
+];
+
+/**
+ * Resolves the client-level secret: the explicit option wins (an explicit
+ * empty string disables provisioning), then the environment, then the
+ * persisted (or generated) secret. An empty result means injection is
+ * disabled. Never throws.
+ */
+export async function resolveUserCacheSecret(explicit?: string): Promise<string> {
+  if (explicit !== undefined) {
+    return explicit;
+  }
+  // A set-but-empty variable counts as set: it disables generation, which is
+  // what pooled multi-user deployments want. Browser bundles have no process.
+  const env = typeof process !== "undefined" ? process.env?.[USER_CACHE_SECRET_ENV] : undefined;
+  if (env !== undefined) {
+    return env;
+  }
+  return loadOrGenerateUserCacheSecret();
+}
+
+/** Returns a fresh 256-bit random secret, hex-encoded. */
+function newUserCacheSecret(): string {
+  try {
+    const bytes = new Uint8Array(32);
+    crypto.getRandomValues(bytes);
+    return Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join("");
+  } catch {
+    // Never fall back to a weak secret: no secret means tenant-wide caching,
+    // which is safe.
+    console.warn(
+      "[tinfoil] could not generate a user cache secret; requests stay in the tenant-wide cache namespace",
+    );
+    return "";
+  }
+}
+
+/**
+ * The process-lifetime fallback for when the secret cannot be persisted. An
+ * unpersisted secret still isolates this process's cache namespace, but
+ * continuity is lost on restart — like a session ID, it silently resets the
+ * namespace every deploy — so the fallback warns once per process.
+ */
+let ephemeralUserCacheSecret: string | undefined;
+
+function getEphemeralUserCacheSecret(): string {
+  if (ephemeralUserCacheSecret === undefined) {
+    ephemeralUserCacheSecret = newUserCacheSecret();
+    if (ephemeralUserCacheSecret !== "") {
+      console.warn(
+        "[tinfoil] could not persist the user cache secret; using an in-memory secret, " +
+          "so prompt-cache continuity resets when this process exits " +
+          `(set ${USER_CACHE_SECRET_ENV} or the userCacheSecret option to pin one)`,
+      );
+    }
+  }
+  return ephemeralUserCacheSecret;
+}
+
+/**
+ * Returns the secret persisted under the user's home directory, generating
+ * and persisting one on first use. Without a usable filesystem (browsers,
+ * edge runtimes, an unwritable home directory) it falls back to the
+ * process-lifetime in-memory secret.
+ */
+async function loadOrGenerateUserCacheSecret(): Promise<string> {
+  if (!isRealBrowser()) {
+    try {
+      // Dynamic import to keep Node.js fs/os modules out of browser bundles;
+      // package.json's browser field maps the store to a stub, the same way
+      // pinned-tls-fetch is gated.
+      const { loadOrPersistUserCacheSecret } = await import("./user-cache-secret-store.js");
+      const secret = loadOrPersistUserCacheSecret(newUserCacheSecret);
+      if (secret !== null) {
+        return secret;
+      }
+    } catch {
+      // No usable filesystem in this runtime: fall through.
+    }
+  }
+  return getEphemeralUserCacheSecret();
+}
+
+/**
+ * Adds the field to a JSON-object body. Returns null — forward the original
+ * body untouched — for non-object bodies, trailing data, or a body that
+ * already carries the field (an explicit per-request value, including an
+ * explicit empty string, always wins).
+ */
+export function injectUserCacheSecret(raw: string, secret: string): string | null {
+  let parsed: unknown;
+  try {
+    // JSON.parse enforces exactly the framing we need: a single
+    // value followed by nothing but whitespace. Trailing data ('{...}}',
+    // '{...} garbage') throws, so a body the server would reject is forwarded
+    // as-is instead of being quietly rewritten into one it accepts.
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    return null;
+  }
+  if (Object.prototype.hasOwnProperty.call(parsed, USER_CACHE_SECRET_FIELD)) {
+    return null;
+  }
+  // Splice the field into the original text instead of re-serializing the
+  // parsed object: parsing round-trips numbers through float64, which would
+  // corrupt int64-range values such as `"seed": 9007199254740993`. The last
+  // '}' is the object's closing brace — only whitespace may follow it.
+  const end = raw.lastIndexOf("}");
+  const field = `${JSON.stringify(USER_CACHE_SECRET_FIELD)}:${JSON.stringify(secret)}`;
+  const separator = Object.keys(parsed).length > 0 ? "," : "";
+  return raw.slice(0, end) + separator + field + raw.slice(end);
+}
+
+/**
+ * Decodes supported replayable in-memory bodies. Other representations are
+ * forwarded unchanged, so callers using them must provide the field.
+ */
+function bodyText(body: BodyInit | null | undefined): string | null {
+  if (typeof body === "string") {
+    return body;
+  }
+  if (body instanceof ArrayBuffer || ArrayBuffer.isView(body)) {
+    try {
+      return new TextDecoder("utf-8", { fatal: true }).decode(body);
+    } catch {
+      return null;
+    }
+  }
+  return null;
+}
+
+/**
+ * Rewrites a caller-supplied Content-Length header to describe the injected
+ * body. Fetch implementations compute the length themselves when the header
+ * is absent, so it is only touched when the caller set one.
+ */
+function headersWithUpdatedBodyMetadata(
+  headers: HeadersInit | undefined,
+  body: string,
+): HeadersInit | undefined {
+  if (headers === undefined) {
+    return headers;
+  }
+  const updated = new Headers(headers);
+  if (updated.has("content-length")) {
+    updated.set("content-length", String(new TextEncoder().encode(body).byteLength));
+    return updated;
+  }
+  return headers;
+}
+
+/**
+ * Injects the client-level secret into an eligible request: a POST with a
+ * JSON-object body to one of the supported endpoints. Anything else — other
+ * endpoints, non-object bodies, or a body that already carries the field —
+ * passes through untouched. Never throws. The caller
+ * runs this inside the sealing boundary, so retries and redirects below the
+ * transport replay the injected body, not the caller's original.
+ */
+export async function injectUserCacheSecretIntoRequestInit(
+  init: RequestInit | undefined,
+  pathname: string,
+  secret: string,
+): Promise<RequestInit | undefined> {
+  if (secret === "" || init === undefined) {
+    return init;
+  }
+  if ((init.method ?? "GET").toUpperCase() !== "POST") {
+    return init;
+  }
+  if (!USER_CACHE_SECRET_PATHS.some((path) => pathname.endsWith(path))) {
+    return init;
+  }
+  const raw = bodyText(init.body);
+  if (raw === null || raw === "") {
+    return init;
+  }
+  const injected = injectUserCacheSecret(raw, secret);
+  if (injected === null) {
+    return init;
+  }
+  return {
+    ...init,
+    body: injected,
+    headers: headersWithUpdatedBodyMetadata(init.headers, injected),
+  };
+}
+
+/**
+ * Wraps a fetch function so eligible request bodies carry the secret. The
+ * wrapper sits directly above the sealing fetch (the TLS connection pinned
+ * to the attested key), so the injected field never travels outside the
+ * protected channel. An empty secret disables injection entirely.
+ */
+export function withUserCacheSecret(
+  inner: typeof fetch,
+  baseURL: string,
+  secret: string,
+): typeof fetch {
+  if (secret === "") {
+    return inner;
+  }
+  return (async (input: RequestInfo | URL, init?: RequestInit) => {
+    let pathname: string;
+    try {
+      pathname = requestPathname(input, baseURL);
+    } catch {
+      // An unresolvable URL is the inner fetch's error to raise.
+      return inner(input, init);
+    }
+    const normalized = input instanceof Request && init?.body !== undefined
+      ? { method: input.method, headers: input.headers, ...init }
+      : init;
+    const injected = await injectUserCacheSecretIntoRequestInit(
+      normalized,
+      pathname,
+      secret,
+    );
+    return inner(input, injected);
+  }) as typeof fetch;
+}
+
+/** Resolves the request path the same way the pinned TLS fetch does. */
+function requestPathname(input: RequestInfo | URL, baseURL: string): string {
+  if (typeof input === "string") {
+    return new URL(input, baseURL).pathname;
+  }
+  if (input instanceof URL) {
+    return input.pathname;
+  }
+  return new URL((input as Request).url, baseURL).pathname;
+}

--- a/packages/tinfoil/test/client.transport.test.ts
+++ b/packages/tinfoil/test/client.transport.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 const MOCK_MEASUREMENT_TYPE = "https://tinfoil.sh/predicate/sev-snp-guest/v1";
 
@@ -90,6 +90,13 @@ vi.mock("../src/atc.js", () => ({
 describe("Secure transport integration", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // Pin the user cache secret so transport creation resolves it from the
+    // environment instead of touching ~/.tinfoil.
+    vi.stubEnv("TINFOIL_USER_CACHE_SECRET", "test-secret");
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
   });
 
   it("configures the OpenAI SDK to use the encrypted body transport", async () => {
@@ -109,7 +116,8 @@ describe("Secure transport integration", () => {
       testBaseURL,
       "mock-hpke-public-key",
       undefined,
-      "https://test-router.tinfoil.sh"
+      "https://test-router.tinfoil.sh",
+      "test-secret"
     );
   });
 

--- a/packages/tinfoil/test/integration.test.ts
+++ b/packages/tinfoil/test/integration.test.ts
@@ -6,6 +6,7 @@ import { fileURLToPath } from "url";
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const RUN_INTEGRATION = process.env.RUN_TINFOIL_INTEGRATION === "true";
+const TEST_USER_CACHE_SECRET = "javascript-live-integration-cache-secret";
 
 /**
  * Integration tests for the Tinfoil SDK.
@@ -24,7 +25,10 @@ describe("Examples Integration Tests", () => {
     const { TinfoilAI } = await import("../src/tinfoil-ai");
     const { SecureClient } = await import("../src/secure-client");
 
-    sharedTinfoilClient = new TinfoilAI({ apiKey: process.env.TINFOIL_API_KEY });
+    sharedTinfoilClient = new TinfoilAI({
+      apiKey: process.env.TINFOIL_API_KEY,
+      userCacheSecret: TEST_USER_CACHE_SECRET,
+    });
     sharedSecureClient = new SecureClient();
 
     // Attest both in parallel
@@ -35,7 +39,7 @@ describe("Examples Integration Tests", () => {
   });
 
   describe("Basic Chat Example", () => {
-    it.skipIf(!RUN_INTEGRATION)("should create a TinfoilAI client and make a chat completion request", async () => {
+    it.skipIf(!RUN_INTEGRATION)("should make a chat completion request with a cache secret", async () => {
       const completion = await sharedTinfoilClient.chat.completions.create({
         messages: [{ role: "user", content: "Hello!" }],
         model: "gpt-oss-120b",

--- a/packages/tinfoil/test/secure-client.browser.test.ts
+++ b/packages/tinfoil/test/secure-client.browser.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 const MOCK_MEASUREMENT_TYPE = "https://tinfoil.sh/predicate/sev-snp-guest/v1";
 
@@ -93,6 +93,13 @@ vi.mock("../src/atc.js", () => ({
 describe("SecureClient (browser)", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // Pin the user cache secret so transport creation resolves it from the
+    // (possibly polyfilled) environment instead of a filesystem.
+    vi.stubEnv("TINFOIL_USER_CACHE_SECRET", "test-secret");
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
   });
 
   it("should reject initialization when HPKE is not available in browser", async () => {

--- a/packages/tinfoil/test/secure-client.test.ts
+++ b/packages/tinfoil/test/secure-client.test.ts
@@ -1,3 +1,5 @@
+import type { SecureTransport } from "../src/encrypted-body-fetch";
+
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 const MOCK_MEASUREMENT_TYPE = "https://tinfoil.sh/predicate/sev-snp-guest/v1";
@@ -33,8 +35,16 @@ const verifyMock = vi.fn(async () => ({
 
 const mockFetch = vi.fn(async () => new Response(JSON.stringify({ message: "success" })));
 const mockGetSessionRecoveryToken = vi.fn(async () => ({ exportedSecret: new Uint8Array(), requestEnc: new Uint8Array() }));
-const createSecureFetchMock = vi.fn(async () => ({
-  fetch: mockFetch,
+const createSecureFetchMock = vi.fn<
+  (
+    baseURL: string,
+    hpkePublicKey?: string,
+    tlsPublicKeyFingerprint?: string,
+    enclaveURL?: string,
+    userCacheSecret?: string,
+  ) => Promise<SecureTransport>
+>(async () => ({
+  fetch: mockFetch as typeof fetch,
   getSessionRecoveryToken: mockGetSessionRecoveryToken,
 }));
 
@@ -95,6 +105,13 @@ vi.mock("../src/atc.js", () => ({
 describe("SecureClient", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // Pin the user cache secret so transport creation resolves it from the
+    // environment instead of touching ~/.tinfoil.
+    vi.stubEnv("TINFOIL_USER_CACHE_SECRET", "test-secret");
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
   });
 
   it("should create a client and initialize securely", async () => {
@@ -113,6 +130,7 @@ describe("SecureClient", () => {
       "mock-hpke-public-key",
       undefined,
       "https://test-router.tinfoil.sh",
+      "test-secret",
     );
   });
 
@@ -486,6 +504,7 @@ describe("SecureClient", () => {
         undefined,
         "mock-tls-public-key-fingerprint",
         "https://test-router.tinfoil.sh",
+        "test-secret",
       );
     });
 
@@ -516,6 +535,38 @@ describe("SecureClient", () => {
       expect(() => {
         new SecureClient({ attestationBundleURL: "" });
       }).toThrow("attestationBundleURL must use HTTPS");
+    });
+  });
+
+  describe("userCacheSecret option", () => {
+    it("beats the environment variable", async () => {
+      const { SecureClient } = await import("../src/secure-client");
+
+      const client = new SecureClient({ userCacheSecret: "option-secret" });
+      await client.ready();
+
+      expect(createSecureFetchMock).toHaveBeenCalledWith(
+        "https://test-router.tinfoil.sh/v1/",
+        "mock-hpke-public-key",
+        undefined,
+        "https://test-router.tinfoil.sh",
+        "option-secret",
+      );
+    });
+
+    it("explicit empty disables injection despite the environment", async () => {
+      const { SecureClient } = await import("../src/secure-client");
+
+      const client = new SecureClient({ userCacheSecret: "" });
+      await client.ready();
+
+      expect(createSecureFetchMock).toHaveBeenCalledWith(
+        "https://test-router.tinfoil.sh/v1/",
+        "mock-hpke-public-key",
+        undefined,
+        "https://test-router.tinfoil.sh",
+        "",
+      );
     });
   });
 
@@ -579,6 +630,51 @@ describe("SecureClient", () => {
       expect(await response.json()).toEqual({ ok: true });
     });
 
+    it("should retry eligible requests with the injected cache secret", async () => {
+      const { SecureClient } = await import("../src/secure-client");
+      const { withUserCacheSecret } = await import("../src/user-cache-secret");
+      const { KeyConfigMismatchError } = await import("ehbp");
+
+      const firstAttempt = vi.fn(async () => {
+        throw new KeyConfigMismatchError("Key config mismatch");
+      }) as typeof fetch;
+      const recoveredAttempt = vi.fn(async () =>
+        new Response(JSON.stringify({ ok: true }))
+      ) as typeof fetch;
+      createSecureFetchMock
+        .mockImplementationOnce(async (baseURL, _hpke, _tls, _enclave, secret) => {
+          return {
+            fetch: withUserCacheSecret(firstAttempt, baseURL!, secret!),
+            getSessionRecoveryToken: mockGetSessionRecoveryToken,
+          };
+        })
+        .mockImplementationOnce(async (baseURL, _hpke, _tls, _enclave, secret) => {
+          return {
+            fetch: withUserCacheSecret(recoveredAttempt, baseURL!, secret!),
+            getSessionRecoveryToken: mockGetSessionRecoveryToken,
+          };
+        });
+
+      const client = new SecureClient({
+        baseURL: "https://test.example.com/",
+      });
+      const response = await client.fetch("/v1/chat/completions", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ model: "m" }),
+      });
+
+      expect(await response.json()).toEqual({ ok: true });
+      expect(firstAttempt).toHaveBeenCalledTimes(1);
+      expect(recoveredAttempt).toHaveBeenCalledTimes(1);
+      for (const [, init] of [
+        ...vi.mocked(firstAttempt).mock.calls,
+        ...vi.mocked(recoveredAttempt).mock.calls,
+      ]) {
+        expect(JSON.parse(init!.body as string).user_cache_secret).toBe("test-secret");
+      }
+    });
+
     it("should propagate non-KeyConfigMismatchError errors", async () => {
       const { SecureClient } = await import("../src/secure-client");
 
@@ -613,6 +709,7 @@ describe("SecureClient", () => {
         "mock-hpke-public-key",
         undefined,
         "https://test-router.tinfoil.sh",
+        "test-secret",
       );
     });
 
@@ -632,6 +729,7 @@ describe("SecureClient", () => {
         "mock-hpke-public-key",
         undefined,
         "https://test-router.tinfoil.sh",
+        "test-secret",
       );
     });
 
@@ -651,6 +749,7 @@ describe("SecureClient", () => {
         "mock-hpke-public-key",
         undefined,
         "https://my-enclave.example.com",
+        "test-secret",
       );
     });
 
@@ -671,6 +770,7 @@ describe("SecureClient", () => {
         "mock-hpke-public-key",
         undefined,
         "https://my-enclave.example.com",
+        "test-secret",
       );
     });
 

--- a/packages/tinfoil/test/secure-client.websocket.test.ts
+++ b/packages/tinfoil/test/secure-client.websocket.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { EventEmitter } from "events";
 
 const MOCK_MEASUREMENT_TYPE = "https://tinfoil.sh/predicate/sev-snp-guest/v2";
@@ -60,6 +60,12 @@ import { fetchAttestationBundle } from "../src/atc.js";
 beforeEach(() => {
   createPinnedWebSocketMock.mockClear();
   vi.mocked(fetchAttestationBundle).mockClear();
+  // Pin the user cache secret so client init never touches ~/.tinfoil.
+  vi.stubEnv("TINFOIL_USER_CACHE_SECRET", "test-secret");
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
 });
 
 describe("SecureClient.createWebSocket", () => {

--- a/packages/tinfoil/test/user-cache-secret.test.ts
+++ b/packages/tinfoil/test/user-cache-secret.test.ts
@@ -1,0 +1,701 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  statSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { spawn } from "node:child_process";
+import { createServer, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import OpenAI from "openai";
+import { Identity, Transport } from "ehbp";
+import {
+  USER_CACHE_SECRET_FIELD,
+  resolveUserCacheSecret,
+  injectUserCacheSecret,
+  withUserCacheSecret,
+} from "../src/user-cache-secret";
+import {
+  USER_CACHE_SECRET_DIR_NAME,
+  USER_CACHE_SECRET_FILE_NAME,
+  loadOrPersistUserCacheSecret,
+} from "../src/user-cache-secret-store";
+import { createEncryptedBodyFetch } from "../src/encrypted-body-fetch";
+
+const BASE_URL = "https://enclave.example.com/v1/";
+
+/**
+ * Points the home directory at `home` for the store's os.homedir() lookup.
+ * Both variables are stubbed because homedir() reads HOME on POSIX but
+ * USERPROFILE on Windows — stubbing HOME alone would leave a Windows run
+ * writing into the developer's real profile.
+ */
+function stubHome(home: string): void {
+  vi.stubEnv("HOME", home);
+  vi.stubEnv("USERPROFILE", home);
+}
+
+/** Points the home directory at a fresh temp directory and returns it. */
+function stubTempHome(): string {
+  const home = mkdtempSync(join(tmpdir(), "tinfoil-ucs-"));
+  stubHome(home);
+  return home;
+}
+
+function secretFilePath(home: string): string {
+  return join(home, USER_CACHE_SECRET_DIR_NAME, USER_CACHE_SECRET_FILE_NAME);
+}
+
+/** A fetch stub that records every call and returns 200 OK. */
+function captureFetch() {
+  const calls: Array<{ input: RequestInfo | URL; init?: RequestInit }> = [];
+  const fetchFn = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    calls.push({ input, init });
+    return new Response("ok", { status: 200 });
+  }) as typeof fetch;
+  return { calls, fetch: fetchFn };
+}
+
+function postJSON(body: string, extraHeaders: Record<string, string> = {}): RequestInit {
+  return {
+    method: "POST",
+    headers: { "Content-Type": "application/json", ...extraHeaders },
+    body,
+  };
+}
+
+function resolveSecretInChild(
+  sourceURL: string,
+  home: string,
+  generatedSecret: string,
+): { ready: Promise<void>; result: Promise<string>; start: () => void } {
+  const script = `
+    import { loadOrPersistUserCacheSecret } from ${JSON.stringify(sourceURL)};
+    process.send("ready");
+    await new Promise((resolve) => process.once("message", resolve));
+    process.send({ result: loadOrPersistUserCacheSecret(() => ${JSON.stringify(generatedSecret)}) });
+    process.disconnect();
+  `;
+  const child = spawn(
+    process.execPath,
+    ["--loader", "ts-node/esm", "--input-type=module", "-e", script],
+    {
+      cwd: fileURLToPath(new URL("..", import.meta.url)),
+      env: { ...process.env, HOME: home, USERPROFILE: home },
+      stdio: ["ignore", "ignore", "pipe", "ipc"],
+    },
+  );
+  let stderr = "";
+  child.stderr.on("data", (chunk) => {
+    stderr += chunk;
+  });
+  const ready = new Promise<void>((resolve, reject) => {
+    child.once("error", reject);
+    child.on("message", (message) => {
+      if (message === "ready") {
+        resolve();
+      }
+    });
+  });
+  const result = new Promise<string>((resolve, reject) => {
+    child.once("error", reject);
+    child.on("message", (message) => {
+      if (typeof message === "object" && message !== null && "result" in message) {
+        resolve(String(message.result));
+      }
+    });
+    child.once("exit", (code) => {
+      if (code !== 0) {
+        reject(new Error(`cache secret child exited with ${code}: ${stderr}`));
+      }
+    });
+  });
+  return {
+    ready,
+    result,
+    start: () => child.send("start"),
+  };
+}
+
+beforeEach(() => {
+  // A developer environment may carry the variable; every test controls it
+  // explicitly. stubEnv(name, undefined) removes it and registers restoration.
+  vi.stubEnv("TINFOIL_USER_CACHE_SECRET", undefined);
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.restoreAllMocks();
+});
+
+describe("resolveUserCacheSecret", () => {
+  it("explicit option beats the environment", async () => {
+    vi.stubEnv("TINFOIL_USER_CACHE_SECRET", "from-env");
+    await expect(resolveUserCacheSecret("explicit")).resolves.toBe("explicit");
+  });
+
+  it("explicit empty counts as set: disables provisioning even with the environment set", async () => {
+    vi.stubEnv("TINFOIL_USER_CACHE_SECRET", "from-env");
+    await expect(resolveUserCacheSecret("")).resolves.toBe("");
+  });
+
+  it("environment beats generation and touches no file", async () => {
+    const home = stubTempHome();
+    vi.stubEnv("TINFOIL_USER_CACHE_SECRET", "from-env");
+
+    await expect(resolveUserCacheSecret()).resolves.toBe("from-env");
+    expect(
+      existsSync(join(home, USER_CACHE_SECRET_DIR_NAME)),
+      "an environment-provided secret must not create the secret file",
+    ).toBe(false);
+  });
+
+  it("environment set but empty disables generation and touches no file", async () => {
+    const home = stubTempHome();
+    vi.stubEnv("TINFOIL_USER_CACHE_SECRET", "");
+
+    await expect(resolveUserCacheSecret()).resolves.toBe("");
+    expect(
+      existsSync(join(home, USER_CACHE_SECRET_DIR_NAME)),
+      "a disabled secret must not create the secret file",
+    ).toBe(false);
+  });
+
+  it("generates a 256-bit hex secret, persists it at 0600, and reuses it", async () => {
+    const home = stubTempHome();
+
+    const first = await resolveUserCacheSecret();
+    expect(first, "expected a hex-encoded 256-bit secret").toMatch(/^[0-9a-f]{64}$/);
+
+    const path = secretFilePath(home);
+    if (process.platform !== "win32") {
+      // Windows has no POSIX permission bits; stat reports a synthesized mode.
+      expect(statSync(join(home, USER_CACHE_SECRET_DIR_NAME)).mode & 0o777).toBe(0o700);
+      expect(statSync(path).mode & 0o777).toBe(0o600);
+    }
+    expect(readFileSync(path, "utf8")).toBe(first);
+
+    // A second resolution (a new client, or another SDK on the same machine)
+    // must reuse the persisted secret, not mint a new namespace.
+    await expect(resolveUserCacheSecret()).resolves.toBe(first);
+  });
+
+  it("accepts permissive existing state without permission maintenance", async () => {
+    const home = stubTempHome();
+    const dir = join(home, USER_CACHE_SECRET_DIR_NAME);
+    mkdirSync(dir, { recursive: true, mode: 0o700 });
+    // Trailing newline: the file may be hand-edited or written by another SDK.
+    const path = join(dir, USER_CACHE_SECRET_FILE_NAME);
+    writeFileSync(path, "shared-secret\n", { mode: 0o600 });
+    if (process.platform !== "win32") {
+      chmodSync(dir, 0o755);
+      chmodSync(path, 0o644);
+    }
+
+    await expect(resolveUserCacheSecret()).resolves.toBe("shared-secret");
+    if (process.platform !== "win32") {
+      expect(statSync(dir).mode & 0o777).toBe(0o755);
+      expect(statSync(path).mode & 0o777).toBe(0o644);
+    }
+  });
+
+  it("keeps a valid destination authoritative", () => {
+    const home = stubTempHome();
+    const dir = join(home, USER_CACHE_SECRET_DIR_NAME);
+    const path = secretFilePath(home);
+    mkdirSync(dir, { recursive: true, mode: 0o700 });
+    writeFileSync(path, "primary-secret", { mode: 0o600 });
+
+    expect(loadOrPersistUserCacheSecret(() => "must-not-be-used")).toBe("primary-secret");
+  });
+
+  it("leaves invalid UTF-8 persistence unchanged and uses a stable process fallback", async () => {
+    const home = stubTempHome();
+    const dir = join(home, USER_CACHE_SECRET_DIR_NAME);
+    const path = secretFilePath(home);
+    const corrupted = new Uint8Array([0xff, 0xfe, 0x61]);
+    mkdirSync(dir, { recursive: true, mode: 0o700 });
+    writeFileSync(path, corrupted, { mode: 0o600 });
+
+    expect(loadOrPersistUserCacheSecret(() => "must-not-be-used")).toBeNull();
+    const first = await resolveUserCacheSecret();
+    await expect(resolveUserCacheSecret()).resolves.toBe(first);
+    expect(first).toMatch(/^[0-9a-f]{64}$/);
+    expect(readFileSync(path)).toEqual(Buffer.from(corrupted));
+  });
+
+  it("leaves a blank destination unchanged and uses a stable process fallback", async () => {
+    const home = stubTempHome();
+    const dir = join(home, USER_CACHE_SECRET_DIR_NAME);
+    mkdirSync(dir, { recursive: true, mode: 0o700 });
+    const path = join(dir, USER_CACHE_SECRET_FILE_NAME);
+    writeFileSync(path, "  \n", { mode: 0o600 });
+
+    const first = await resolveUserCacheSecret();
+    await expect(resolveUserCacheSecret()).resolves.toBe(first);
+    expect(first).toMatch(/^[0-9a-f]{64}$/);
+    expect(readFileSync(path, "utf8")).toBe("  \n");
+  });
+
+  it("persists consistently across concurrent processes on first use", async () => {
+    const home = stubTempHome();
+    const dir = join(home, USER_CACHE_SECRET_DIR_NAME);
+    mkdirSync(dir, { recursive: true, mode: 0o700 });
+    const path = secretFilePath(home);
+    const sourceURL = new URL("../src/user-cache-secret-store.ts", import.meta.url).href;
+    const children = Array.from({ length: 6 }, (_, index) =>
+      resolveSecretInChild(sourceURL, home, `child-secret-${index}`),
+    );
+    await Promise.all(children.map((child) => child.ready));
+    children.forEach((child) => child.start());
+    const results = await Promise.all(children.map((child) => child.result));
+
+    expect(new Set(results).size).toBe(1);
+    expect(readFileSync(path, "utf8")).toBe(results[0]);
+    if (process.platform !== "win32") {
+      expect(statSync(dir).mode & 0o777).toBe(0o700);
+      expect(statSync(path).mode & 0o777).toBe(0o600);
+    }
+  });
+
+  it.each(["destination", "directory"])(
+    "rejects a symlinked %s without changing its target",
+    (symlinkKind) => {
+      if (process.platform === "win32") {
+        return;
+      }
+      const home = stubTempHome();
+      const targetDir = mkdtempSync(join(tmpdir(), "tinfoil-ucs-target-"));
+      const targetPath = join(targetDir, "target");
+      writeFileSync(targetPath, "target-secret", { mode: 0o644 });
+      chmodSync(targetDir, 0o755);
+
+      const dir = join(home, USER_CACHE_SECRET_DIR_NAME);
+      const path = secretFilePath(home);
+      if (symlinkKind === "directory") {
+        symlinkSync(targetDir, dir, "dir");
+      } else {
+        mkdirSync(dir, { recursive: true, mode: 0o700 });
+        symlinkSync(targetPath, path);
+      }
+
+      expect(loadOrPersistUserCacheSecret(() => "must-not-be-used")).toBeNull();
+      expect(readFileSync(targetPath, "utf8")).toBe("target-secret");
+      expect(statSync(targetPath).mode & 0o777).toBe(0o644);
+      if (symlinkKind === "directory") {
+        expect(statSync(targetDir).mode & 0o777).not.toBe(0o700);
+      }
+    },
+  );
+
+  it("rejects a non-regular destination", () => {
+    const home = stubTempHome();
+    const dir = join(home, USER_CACHE_SECRET_DIR_NAME);
+    mkdirSync(dir, { recursive: true });
+    mkdirSync(secretFilePath(home));
+
+    expect(loadOrPersistUserCacheSecret(() => "must-not-be-used")).toBeNull();
+    expect(statSync(secretFilePath(home)).isDirectory()).toBe(true);
+  });
+
+  it("preserves missing-path persistence semantics on Windows", async () => {
+    const home = stubTempHome();
+    vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+    vi.resetModules();
+
+    const { loadOrPersistUserCacheSecret: loadWindowsSecret } =
+      await import("../src/user-cache-secret-store");
+    expect(loadWindowsSecret(() => "windows-secret")).toBe("windows-secret");
+    expect(readFileSync(secretFilePath(home), "utf8")).toBe("windows-secret");
+  });
+
+  it("falls back to a stable in-memory secret without a home directory, warning once", async () => {
+    stubHome("");
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    // The ephemeral secret and its one-time warning are module-level state,
+    // and other tests in this file (the unwritable-home one) may legitimately
+    // reach the fallback first. Import a fresh module instance so this test
+    // observes the warn-once behavior from a cold start, whatever the order.
+    vi.resetModules();
+    const { resolveUserCacheSecret: freshResolve } = await import("../src/user-cache-secret");
+
+    const first = await freshResolve();
+    expect(first, "no home directory must still yield a process-lifetime secret").toMatch(/^[0-9a-f]{64}$/);
+    await expect(
+      freshResolve(),
+      "the in-memory fallback must be stable within the process",
+    ).resolves.toBe(first);
+
+    const fallbackWarnings = warnSpy.mock.calls.filter(([msg]) =>
+      String(msg).includes("TINFOIL_USER_CACHE_SECRET"),
+    );
+    expect(fallbackWarnings, "the ephemeral fallback must warn exactly once per process").toHaveLength(1);
+  });
+
+  it("falls back when the home path is not a directory", async () => {
+    const notADir = join(mkdtempSync(join(tmpdir(), "tinfoil-ucs-")), "not-a-dir");
+    writeFileSync(notADir, "x");
+    stubHome(notADir);
+
+    await expect(resolveUserCacheSecret()).resolves.not.toBe("");
+  });
+});
+
+describe("withUserCacheSecret", () => {
+  const eligiblePaths = [
+    "/v1/chat/completions",
+    "/v1/completions",
+    "/v1/responses",
+    "/api/v1/chat/completions", // proxy base URL with a path prefix
+    "/chat/completions", // custom base URL without a /v1 root
+  ];
+
+  for (const path of eligiblePaths) {
+    it(`injects on ${path}`, async () => {
+      const { calls, fetch: inner } = captureFetch();
+      const secureFetch = withUserCacheSecret(inner, BASE_URL, "s1");
+
+      const raw = '{"model":"m"}';
+      const response = await secureFetch(
+        `https://enclave.example.com${path}`,
+        postJSON(raw, { "Content-Length": String(raw.length) }),
+      );
+      expect(response.status).toBe(200);
+
+      const sent = calls[0].init!;
+      const body = JSON.parse(sent.body as string);
+      expect(body[USER_CACHE_SECRET_FIELD]).toBe("s1");
+      expect(body.model).toBe("m");
+
+      // Length metadata must describe the injected bytes, and re-sending the
+      // request (retry machinery re-runs the wrapper) must produce the same
+      // injected body.
+      const injectedLength = new TextEncoder().encode(sent.body as string).byteLength;
+      expect(new Headers(sent.headers).get("content-length")).toBe(String(injectedLength));
+      await secureFetch(`https://enclave.example.com${path}`, postJSON(raw));
+      expect(calls[1].init!.body).toBe(sent.body);
+    });
+  }
+
+  it.each([
+    "/v1/embeddings",
+    "/embeddings",
+  ])("skips non-allowlisted endpoints, forwarding the body byte-identical: %s", async (path) => {
+    const { calls, fetch: inner } = captureFetch();
+    const secureFetch = withUserCacheSecret(inner, BASE_URL, "s1");
+
+    const raw = '{"model":"m","input":"text"}';
+    await secureFetch(`https://enclave.example.com${path}`, postJSON(raw));
+    expect(calls[0].init!.body).toBe(raw);
+  });
+
+  it("forwards a GET with no body as-is", async () => {
+    const { calls, fetch: inner } = captureFetch();
+    const secureFetch = withUserCacheSecret(inner, BASE_URL, "s1");
+
+    const init: RequestInit = { method: "GET" };
+    const response = await secureFetch("https://enclave.example.com/v1/models", init);
+    expect(response.status).toBe(200);
+    expect(calls[0].init).toBe(init);
+  });
+
+  it("an empty secret disables injection entirely", async () => {
+    const { calls, fetch: inner } = captureFetch();
+    const secureFetch = withUserCacheSecret(inner, BASE_URL, "");
+    expect(secureFetch).toBe(inner);
+
+    const raw = '{"model":"m"}';
+    await secureFetch("https://enclave.example.com/v1/chat/completions", postJSON(raw));
+    expect(calls[0].init!.body).toBe(raw);
+  });
+
+  it.each([
+    ["explicit per-request secret", '{"model":"m","user_cache_secret":"end-user-7"}'],
+    ["explicit empty opt-out", '{"model":"m","user_cache_secret":""}'],
+  ])("never clobbers a pre-existing field: %s", async (_name, raw) => {
+    const { calls, fetch: inner } = captureFetch();
+    const secureFetch = withUserCacheSecret(inner, BASE_URL, "client-level");
+
+    await secureFetch("https://enclave.example.com/v1/chat/completions", postJSON(raw));
+    expect(
+      calls[0].init!.body,
+      "a body that already carries the field must pass through byte-identical",
+    ).toBe(raw);
+  });
+
+  it.each([
+    "not json",
+    "[1,2,3]",
+    "null",
+    '{"model":"m"} trailing',
+    '{"model":"m"}}',
+    '{"model":"m"}]',
+    '{"model":"m"}} garbage',
+  ])("forwards a non-object body untouched: %s", async (raw) => {
+    // The trailing '}' / ']' cases matter: a lenient parser would re-serialize
+    // the leading object and silently drop the trailing bytes, turning a body
+    // the server rejects into one it accepts.
+    const { calls, fetch: inner } = captureFetch();
+    const secureFetch = withUserCacheSecret(inner, BASE_URL, "s1");
+
+    await secureFetch("https://enclave.example.com/v1/chat/completions", postJSON(raw));
+    expect(calls[0].init!.body).toBe(raw);
+  });
+
+  it.each([
+    ["ArrayBuffer", new TextEncoder().encode('{"model":"m"}').buffer],
+    ["typed array", new TextEncoder().encode('{"model":"m"}')],
+    ["DataView", new DataView(new TextEncoder().encode('{"model":"m"}').buffer)],
+  ])("injects into an ordinary UTF-8 %s body", async (_name, requestBody) => {
+    const { calls, fetch: inner } = captureFetch();
+    const secureFetch = withUserCacheSecret(inner, BASE_URL, "s1");
+
+    await secureFetch("https://enclave.example.com/v1/chat/completions", {
+      method: "POST",
+      body: requestBody,
+    });
+
+    const body = JSON.parse(calls[0].init!.body as string);
+    expect(body[USER_CACHE_SECRET_FIELD]).toBe("s1");
+    expect(body.model).toBe("m");
+  });
+
+  it("forwards an unsupported stream body unchanged", async () => {
+    const { calls, fetch: inner } = captureFetch();
+    const secureFetch = withUserCacheSecret(inner, BASE_URL, "s1");
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode('{"model":"m"}'));
+        controller.close();
+      },
+    });
+
+    await secureFetch("https://enclave.example.com/v1/chat/completions", {
+      method: "POST",
+      body: stream,
+      duplex: "half",
+    } as RequestInit);
+
+    expect(calls[0].init!.body).toBe(stream);
+  });
+
+  it("forwards a Request body unchanged", async () => {
+    const { calls, fetch: inner } = captureFetch();
+    const secureFetch = withUserCacheSecret(inner, BASE_URL, "s1");
+    const request = new Request(
+      "https://enclave.example.com/v1/chat/completions",
+      postJSON('{"model":"m"}'),
+    );
+
+    await secureFetch(request);
+
+    expect(calls[0].input).toBe(request);
+    expect(calls[0].init).toBeUndefined();
+    expect(request.bodyUsed).toBe(false);
+  });
+
+  it("preserves Request headers when an init body overrides the Request body", async () => {
+    const { calls, fetch: inner } = captureFetch();
+    const secureFetch = withUserCacheSecret(inner, BASE_URL, "s1");
+    const request = new Request(
+      "https://enclave.example.com/v1/chat/completions",
+      postJSON('{"model":"request"}', {
+        "Content-Length": "1",
+        "X-Source": "request",
+      }),
+    );
+
+    await secureFetch(request, { body: '{"model":"override"}' });
+
+    const sent = calls[0].init!;
+    const body = JSON.parse(sent.body as string);
+    const headers = new Headers(sent.headers);
+    expect(body.model).toBe("override");
+    expect(body[USER_CACHE_SECRET_FIELD]).toBe("s1");
+    expect(headers.get("content-type")).toBe("application/json");
+    expect(headers.get("x-source")).toBe("request");
+    expect(headers.get("content-length")).toBe(
+      String(new TextEncoder().encode(sent.body as string).byteLength),
+    );
+  });
+
+  it("prefers init headers when an init body overrides a Request body", async () => {
+    const { calls, fetch: inner } = captureFetch();
+    const secureFetch = withUserCacheSecret(inner, BASE_URL, "s1");
+    const request = new Request(
+      "https://enclave.example.com/v1/chat/completions",
+      postJSON('{"model":"request"}', { "X-Source": "request" }),
+    );
+
+    await secureFetch(request, {
+      body: '{"model":"override"}',
+      headers: {
+        "Content-Type": "application/json",
+        "X-Source": "init",
+      },
+    });
+
+    const sent = calls[0].init!;
+    const body = JSON.parse(sent.body as string);
+    expect(body[USER_CACHE_SECRET_FIELD]).toBe("s1");
+    expect(new Headers(sent.headers).get("x-source")).toBe("init");
+  });
+
+  it("forwards an invalid UTF-8 typed-array body byte-identical", async () => {
+    const bytes = new Uint8Array([0x7b, 0x22, 0x6e, 0x22, 0x3a, 0x22, 0xff, 0x22, 0x7d]);
+    const { calls, fetch: inner } = captureFetch();
+    const secureFetch = withUserCacheSecret(inner, BASE_URL, "s1");
+
+    await secureFetch("https://enclave.example.com/v1/chat/completions", {
+      method: "POST",
+      body: bytes,
+    });
+    expect(calls[0].init!.body).toBe(bytes);
+  });
+
+  it("still injects with trailing whitespace after the object", async () => {
+    // Trailing whitespace is not trailing data: strict JSON parsers accept
+    // it, so the injection must too — clients routinely end bodies with \n.
+    const { calls, fetch: inner } = captureFetch();
+    const secureFetch = withUserCacheSecret(inner, BASE_URL, "s1");
+
+    await secureFetch("https://enclave.example.com/v1/chat/completions", postJSON('{"model":"m"}\n\t '));
+    const body = JSON.parse(calls[0].init!.body as string);
+    expect(body[USER_CACHE_SECRET_FIELD]).toBe("s1");
+    expect(body.model).toBe("m");
+  });
+
+  it("preserves number precision across injection", async () => {
+    // 2^53+1 is not representable as a float64; re-serializing the parsed
+    // object (instead of splicing the original text) would corrupt it.
+    const { calls, fetch: inner } = captureFetch();
+    const secureFetch = withUserCacheSecret(inner, BASE_URL, "s1");
+
+    await secureFetch(
+      "https://enclave.example.com/v1/chat/completions",
+      postJSON('{"model":"m","seed":9007199254740993}'),
+    );
+    const sent = calls[0].init!.body as string;
+    expect(sent).toContain('"seed":9007199254740993');
+    expect(JSON.parse(sent)[USER_CACHE_SECRET_FIELD]).toBe("s1");
+  });
+
+  it("injects into an empty JSON object without a stray comma", () => {
+    expect(injectUserCacheSecret("{}", "s1")).toBe('{"user_cache_secret":"s1"}');
+  });
+});
+
+describe("createEncryptedBodyFetch user cache secret", () => {
+  it("injects before the EHBP transport seals the body", async () => {
+    // Capture the plaintext handed to the sealing transport: the field must
+    // be present there, so it is encrypted with the rest of the body.
+    const requestSpy = vi
+      .spyOn(Transport.prototype, "request")
+      .mockImplementation(async () => new Response("ok", { status: 200 }));
+
+    const identity = await Identity.generate();
+    const transport = createEncryptedBodyFetch(
+      "https://enclave.example.com",
+      await identity.getPublicKeyHex(),
+      undefined,
+      "s1",
+    );
+
+    await transport.fetch("/v1/chat/completions", postJSON('{"model":"m"}'));
+
+    const [url, init] = requestSpy.mock.calls[0];
+    expect(url).toBe("https://enclave.example.com/v1/chat/completions");
+    expect(JSON.parse(init!.body as string)[USER_CACHE_SECRET_FIELD]).toBe("s1");
+  });
+
+  it("leaves a caller-set field untouched inside the sealing boundary", async () => {
+    const requestSpy = vi
+      .spyOn(Transport.prototype, "request")
+      .mockImplementation(async () => new Response("ok", { status: 200 }));
+
+    const identity = await Identity.generate();
+    const transport = createEncryptedBodyFetch(
+      "https://enclave.example.com",
+      await identity.getPublicKeyHex(),
+      undefined,
+      "client-level",
+    );
+
+    const raw = '{"model":"m","user_cache_secret":"end-user-7"}';
+    await transport.fetch("/v1/chat/completions", postJSON(raw));
+
+    expect(requestSpy.mock.calls[0][1]!.body).toBe(raw);
+  });
+});
+
+describe("user cache secret through the OpenAI client", () => {
+  let server: Server;
+  let baseURL: string;
+  const received: Array<{ path: string; body: Record<string, unknown> }> = [];
+
+  beforeEach(async () => {
+    received.length = 0;
+    server = createServer((req, res) => {
+      let data = "";
+      req.on("data", (chunk) => (data += chunk));
+      req.on("end", () => {
+        received.push({ path: req.url!, body: JSON.parse(data) });
+        res.setHeader("Content-Type", "application/json");
+        res.end(
+          JSON.stringify({
+            id: "c1",
+            object: "chat.completion",
+            created: 0,
+            model: "m",
+            choices: [
+              { index: 0, message: { role: "assistant", content: "ok" }, finish_reason: "stop" },
+            ],
+          }),
+        );
+      });
+    });
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    baseURL = `http://127.0.0.1:${(server.address() as AddressInfo).port}/v1`;
+  });
+
+  afterEach(async () => {
+    await new Promise((resolve) => server.close(resolve));
+  });
+
+  it("the client-level secret rides real requests; a per-request field wins", async () => {
+    // Drive the real OpenAI client through the injection wrapper, pinning
+    // that the secret rides requests exactly as the SDK builds them.
+    const oai = new OpenAI({
+      apiKey: "test",
+      baseURL,
+      fetch: withUserCacheSecret(fetch, baseURL, "client-level"),
+    });
+
+    const params: OpenAI.ChatCompletionCreateParams = {
+      messages: [{ role: "user", content: "hi" }],
+      model: "m",
+    };
+
+    await oai.chat.completions.create(params);
+    expect(received[0].path).toBe("/v1/chat/completions");
+    expect(received[0].body[USER_CACHE_SECRET_FIELD]).toBe("client-level");
+    expect(received[0].body.model).toBe("m");
+
+    // A per-request field set through the public API must win over the
+    // client-level secret.
+    await oai.chat.completions.create({
+      ...params,
+      [USER_CACHE_SECRET_FIELD]: "end-user-7",
+    } as OpenAI.ChatCompletionCreateParams);
+    expect(received[1].body[USER_CACHE_SECRET_FIELD]).toBe("end-user-7");
+  });
+});

--- a/packages/tinfoil/vite.config.browser-test.ts
+++ b/packages/tinfoil/vite.config.browser-test.ts
@@ -4,6 +4,9 @@ import { resolve } from "path";
 import { playwright } from "@vitest/browser-playwright";
 
 export default defineConfig({
+  optimizeDeps: {
+    include: ["openai"],
+  },
   define: {
     'process.env.TINFOIL_API_KEY': JSON.stringify(process.env.TINFOIL_API_KEY ?? ''),
   },

--- a/packages/verifier/package.json
+++ b/packages/verifier/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tinfoilsh/verifier",
-  "version": "1.1.8",
+  "version": "1.1.9",
   "description": "AMD SEV-SNP attestation verifier for Node.js and browsers",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Scopes prompt caching per user by injecting a `user_cache_secret` into OpenAI‑compatible requests in the `tinfoil` JS SDK. The router consumes it to namespace caches, it’s encrypted in transit and never reaches the model; works with EHBP and pinned TLS, with per‑machine persistence and in‑memory fallback. Ships in `tinfoil` 1.1.9.

- New Features
  - Auto-injects on POSTs to `/chat/completions`, `/completions`, and `/responses` (suffix match; proxy prefixes and `/v1`‑less bases supported).
  - New `userCacheSecret` option on `TinfoilAI`, `SecureClient`, `createTinfoilAI`; precedence: per-request `user_cache_secret` > option > `TINFOIL_USER_CACHE_SECRET` (empty disables) > generated 256‑bit hex at `~/.tinfoil/user_cache_secret` (browser builds fall back to in‑memory).
  - Injection happens inside the sealing boundary for both EHBP and pinned TLS; supports JSON bodies from strings/ArrayBuffer/typed arrays, preserves number precision, and rewrites `Content-Length` when present.

- Bug Fixes
  - Allowlist no longer requires a literal `/v1` prefix.
  - Robust body handling: `Request` bodies pass through unchanged; non‑JSON or invalid UTF‑8 bodies are forwarded; retries replay the injected body.
  - Secret persistence is hardened: atomic temp‑file + hard‑link publish; never overrides a valid file; rejects symlinks/junctions and non‑regular files; respects 0700/0600 modes; Windows‑safe; resolution never throws and cleanly falls back to in‑memory with a one‑time warning.

<sup>Written for commit 40e263b8df3e93e4e29f3167522ab4cb88b34b95. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-js/pull/177?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

