### PR TITLE
fix: support local proxies across secure transports

### DIFF
--- a/packages/tinfoil/src/encrypted-body-fetch.ts
+++ b/packages/tinfoil/src/encrypted-body-fetch.ts
@@ -98,9 +98,6 @@ const ENCLAVE_URL_HEADER = 'X-Tinfoil-Enclave-Url';
 
 export function createEncryptedBodyFetch(baseURL: string, hpkePublicKey: string, enclaveURL?: string): SecureTransport {
   const base = new URL(baseURL);
-  if (base.protocol !== 'https:') {
-    throw new ConfigurationError(`baseURL must use HTTPS. Got: ${baseURL}`);
-  }
   const baseOrigin = base.origin;
   const needsEnclaveHeader = !!enclaveURL && new URL(enclaveURL).origin !== baseOrigin;
 

--- a/packages/tinfoil/src/encrypted-body-fetch.ts
+++ b/packages/tinfoil/src/encrypted-body-fetch.ts
@@ -24,10 +24,6 @@ async function createIdentityFromPublicKeyHex(publicKeyHex: string): Promise<Ide
 export async function getServerIdentity(enclaveURL: string): Promise<Identity> {
   const keysURL = new URL(PROTOCOL.KEYS_PATH, enclaveURL);
 
-  if (keysURL.protocol !== 'https:') {
-    throw new ConfigurationError(`HTTPS is required for key retrieval. Got ${keysURL.protocol}`);
-  }
-
   const response = await fetch(keysURL.toString());
 
   if (!response.ok) {

--- a/packages/tinfoil/src/secure-client.ts
+++ b/packages/tinfoil/src/secure-client.ts
@@ -136,9 +136,22 @@ export class SecureClient {
   private attestedTlsPublicKeyFingerprint?: string;
 
   constructor(options: SecureClientOptions = {}) {
-    // Validate security-critical URLs, including the empty string: URL resolution
+    // Validate provided URLs, including the empty string: URL resolution
     // keeps "" (via ??) rather than falling back, so an unguarded empty value
     // would surface later as a confusing "Invalid URL" instead of a clear error.
+    if (options.baseURL !== undefined) {
+      let baseURL: URL;
+      try {
+        baseURL = new URL(options.baseURL);
+      } catch (cause) {
+        throw new ConfigurationError(`baseURL must be a valid HTTP(S) URL. Got: ${options.baseURL}`, {
+          cause: cause as Error,
+        });
+      }
+      if (baseURL.protocol !== "http:" && baseURL.protocol !== "https:") {
+        throw new ConfigurationError(`baseURL must be a valid HTTP(S) URL. Got: ${options.baseURL}`);
+      }
+    }
     if (options.enclaveURL !== undefined && !options.enclaveURL.startsWith("https://")) {
       throw new ConfigurationError(`enclaveURL must use HTTPS. Got: ${options.enclaveURL}`);
     }

--- a/packages/tinfoil/src/secure-client.ts
+++ b/packages/tinfoil/src/secure-client.ts
@@ -32,8 +32,8 @@ export type TransportMode = 'ehbp' | 'tls';
 export interface SecureClientOptions {
   /**
    * Override the base URL for API requests.
-   * When set, requests are sent to this URL instead of directly to the enclave.
-   * Useful for proxying requests through your own backend.
+   * This may be a proxy URL when using EHBP or a custom path on the enclave
+   * origin when using TLS pinning.
    * @see https://docs.tinfoil.sh/guides/proxy-server
    */
   baseURL?: string;
@@ -145,11 +145,6 @@ export class SecureClient {
     if (options.attestationBundleURL !== undefined && !options.attestationBundleURL.startsWith("https://")) {
       throw new ConfigurationError(`attestationBundleURL must use HTTPS. Got: ${options.attestationBundleURL}`);
     }
-    // Routing through a proxy base URL relies on EHBP sealing the body to the
-    // enclave; TLS certificate pinning would reject the proxy's certificate.
-    if (options.baseURL && options.transport === 'tls') {
-      throw new ConfigurationError("baseURL is only supported with the 'ehbp' transport");
-    }
     if (options.configRepo && !options.enclaveURL) {
       throw new ConfigurationError("configRepo requires enclaveURL — without it, ATC always uses the default router repo.");
     } else if (options.enclaveURL && !options.configRepo) {
@@ -242,8 +237,16 @@ export class SecureClient {
     // Resolve enclaveURL: user-provided config takes precedence, otherwise from bundle
     this.resolvedEnclaveURL = this.config.enclaveURL ?? `https://${bundle.domain}`;
 
-    // Resolve baseURL: user-provided config (proxy) takes precedence, otherwise from enclave
-    this.resolvedBaseURL = this.config.baseURL ?? `${this.resolvedEnclaveURL}/v1/`;
+    // Resolve baseURL: user-provided config takes precedence, otherwise use the enclave API
+    this.resolvedBaseURL = this.config.baseURL ?? this.getEnclaveBaseURL();
+
+    if (
+      this.config.transport === 'tls' &&
+      this.config.baseURL &&
+      new URL(this.resolvedBaseURL!).origin !== new URL(this.resolvedEnclaveURL).origin
+    ) {
+      throw new ConfigurationError("TLS transport requires baseURL to use the verified enclave origin");
+    }
 
     const verifier = new Verifier({
       configRepo: this.config.configRepo,
@@ -283,6 +286,13 @@ export class SecureClient {
    */
   public getEnclaveURL(): string | undefined {
     return this.resolvedEnclaveURL;
+  }
+
+  /**
+   * Get the direct API base URL of the enclave, or undefined before ready().
+   */
+  public getEnclaveBaseURL(): string | undefined {
+    return this.resolvedEnclaveURL ? `${this.resolvedEnclaveURL}/v1/` : undefined;
   }
 
   private async createTransport(hpkePublicKey?: string, tlsPublicKeyFingerprint?: string): Promise<SecureTransport> {
@@ -350,8 +360,8 @@ export class SecureClient {
    *
    * WebSockets can't be covered by EHBP (it only seals HTTP bodies), so they
    * are secured by connecting directly to the enclave with the TLS connection
-   * pinned to the attested key. That rules out browsers (no TLS cert access)
-   * and proxy baseURLs (the proxy's certificate would not match the pin).
+   * pinned to the attested key. That rules out browsers, which do not expose
+   * TLS certificate details.
    */
   private async requireWebSocketCapability(): Promise<string> {
     if (isRealBrowser()) {
@@ -360,14 +370,6 @@ export class SecureClient {
         "expose TLS certificate details, so the connection cannot be pinned to the attested enclave key."
       );
     }
-    if (this.config.baseURL) {
-      throw new ConfigurationError(
-        "WebSockets are not supported with a proxy baseURL: the connection is pinned to the " +
-        "enclave's attested TLS key, which a TLS-terminating proxy cannot present. " +
-        "Use a client without baseURL for realtime connections."
-      );
-    }
-
     await this.ready();
 
     if (!this.attestedTlsPublicKeyFingerprint) {
@@ -393,7 +395,7 @@ export class SecureClient {
    * Opens a WebSocket to the verified enclave with the TLS connection pinned
    * to the attested enclave key.
    *
-   * Node.js only. Not supported with a proxy `baseURL`.
+   * Node.js only. Connections are made directly to the verified enclave.
    *
    * The returned socket is a standard `ws` WebSocket in the CONNECTING state;
    * pinning failures surface as an `error` event. A pin failure drops the cached

--- a/packages/tinfoil/src/secure-client.ts
+++ b/packages/tinfoil/src/secure-client.ts
@@ -136,16 +136,11 @@ export class SecureClient {
   private attestedTlsPublicKeyFingerprint?: string;
 
   constructor(options: SecureClientOptions = {}) {
-    // Validate every provided URL, including the empty string: URL resolution
+    // Validate security-critical URLs, including the empty string: URL resolution
     // keeps "" (via ??) rather than falling back, so an unguarded empty value
     // would surface later as a confusing "Invalid URL" instead of a clear error.
     if (options.enclaveURL !== undefined && !options.enclaveURL.startsWith("https://")) {
       throw new ConfigurationError(`enclaveURL must use HTTPS. Got: ${options.enclaveURL}`);
-    }
-    // A proxy base URL and the attestation bundle URL both carry security-critical
-    // traffic (plaintext headers and the entire trust root), so they must be HTTPS.
-    if (options.baseURL !== undefined && !options.baseURL.startsWith("https://")) {
-      throw new ConfigurationError(`baseURL must use HTTPS. Got: ${options.baseURL}`);
     }
     if (options.attestationBundleURL !== undefined && !options.attestationBundleURL.startsWith("https://")) {
       throw new ConfigurationError(`attestationBundleURL must use HTTPS. Got: ${options.attestationBundleURL}`);

--- a/packages/tinfoil/src/tinfoil-ai.ts
+++ b/packages/tinfoil/src/tinfoil-ai.ts
@@ -215,7 +215,7 @@ export class TinfoilAI {
    * Returns an `OpenAIRealtimeWS` from the OpenAI SDK, connected to the
    * enclave with the TLS connection pinned to the attested enclave key.
    *
-   * Node.js only. Not supported with a proxy `baseURL`.
+   * Node.js only. Connections are made directly to the verified enclave.
    *
    * @example
    * ```typescript
@@ -230,7 +230,7 @@ export class TinfoilAI {
     const { createPinnedRealtimeWS } = await import("./realtime.js");
     return createPinnedRealtimeWS(
       props,
-      { apiKey: client.apiKey as string, baseURL: client.baseURL },
+      { apiKey: client.apiKey as string, baseURL: this.secureClient.getEnclaveBaseURL()! },
       pinnedOptions,
     );
   }

--- a/packages/tinfoil/test/client.transport.test.ts
+++ b/packages/tinfoil/test/client.transport.test.ts
@@ -34,6 +34,7 @@ const verifyMock = vi.fn(async () => ({
 
 const mockFetch = vi.fn(async () => new Response(null));
 const createSecureFetchMock = vi.fn(async () => ({ fetch: mockFetch, getSessionRecoveryToken: vi.fn() }));
+const createPinnedRealtimeWSMock = vi.fn(async () => ({}));
 
 vi.mock("../src/verifier.js", () => ({
   Verifier: class {
@@ -69,6 +70,10 @@ vi.mock("../src/verifier.js", () => ({
 
 vi.mock("../src/secure-fetch.js", () => ({
   createSecureFetch: createSecureFetchMock,
+}));
+
+vi.mock("../src/realtime.js", () => ({
+  createPinnedRealtimeWS: createPinnedRealtimeWSMock,
 }));
 
 vi.mock("../src/atc.js", () => ({
@@ -113,6 +118,25 @@ describe("Secure transport integration", () => {
     const provider = await createTinfoilAI("api-key");
 
     expect(provider).toBeTruthy();
+  });
+
+  it("connects realtime sessions directly to the enclave when using a proxy", async () => {
+    const { TinfoilAI } = await import("../src/tinfoil-ai");
+    const client = new TinfoilAI({
+      apiKey: "test",
+      baseURL: "http://localhost:3000/v1/",
+    });
+
+    await client.realtime({ model: "test-model" });
+
+    expect(createPinnedRealtimeWSMock).toHaveBeenCalledWith(
+      { model: "test-model" },
+      {
+        apiKey: "test",
+        baseURL: "https://test-router.tinfoil.sh/v1/",
+      },
+      expect.any(Object),
+    );
   });
 
   it("TinfoilAI throws when no API key is available (no env var)", async () => {

--- a/packages/tinfoil/test/encrypted-body-fetch.test.ts
+++ b/packages/tinfoil/test/encrypted-body-fetch.test.ts
@@ -4,10 +4,23 @@ import { Identity, PROTOCOL } from "ehbp";
 
 describe("encrypted-body-fetch", () => {
   describe("getServerIdentity", () => {
-    it("rejects non-HTTPS URLs", async () => {
-      await expect(getServerIdentity("http://example.com/v1")).rejects.toThrow(
-        /HTTPS is required for key retrieval/
-      );
+    it("retrieves keys from a non-HTTPS URL", async () => {
+      const mockIdentity = await Identity.generate();
+      const publicConfig = await mockIdentity.marshalConfig();
+      const fetchMock = vi.fn(async () => new Response(publicConfig as unknown as BodyInit, {
+        status: 200,
+        headers: { "content-type": PROTOCOL.KEYS_MEDIA_TYPE },
+      }));
+
+      const originalFetch = globalThis.fetch;
+      globalThis.fetch = fetchMock as typeof fetch;
+
+      try {
+        await expect(getServerIdentity("http://localhost:3000/v1")).resolves.toBeInstanceOf(Identity);
+        expect(fetchMock).toHaveBeenCalledWith("http://localhost:3000/.well-known/hpke-keys");
+      } finally {
+        globalThis.fetch = originalFetch;
+      }
     });
 
     it("rejects invalid content-type", async () => {
@@ -272,7 +285,7 @@ describe("encrypted-body-fetch", () => {
         return new Response("ok");
       }) as typeof fetch;
 
-      const transport = createUnverifiedEncryptedBodyFetch("https://api.example.com");
+      const transport = createUnverifiedEncryptedBodyFetch("http://api.example.com");
       await transport.fetch("/test");
 
       expect(keyFetched).toBe(true);

--- a/packages/tinfoil/test/encrypted-body-fetch.test.ts
+++ b/packages/tinfoil/test/encrypted-body-fetch.test.ts
@@ -184,10 +184,8 @@ describe("encrypted-body-fetch", () => {
       expect(typeof transport.getSessionRecoveryToken).toBe("function");
     });
 
-    it("rejects a non-HTTPS baseURL", () => {
-      expect(() => createEncryptedBodyFetch("http://api.example.com", "mockkey123")).toThrow(
-        /baseURL must use HTTPS/
-      );
+    it("allows a non-HTTPS baseURL", () => {
+      expect(() => createEncryptedBodyFetch("http://api.example.com", "mockkey123")).not.toThrow();
     });
 
     it("refuses requests to an origin outside the enclave/proxy", async () => {

--- a/packages/tinfoil/test/secure-client.test.ts
+++ b/packages/tinfoil/test/secure-client.test.ts
@@ -448,12 +448,12 @@ describe("SecureClient", () => {
       consoleSpy.mockRestore();
     });
 
-    it("should throw ConfigurationError when baseURL is not HTTPS", async () => {
+    it("should allow a non-HTTPS baseURL", async () => {
       const { SecureClient } = await import("../src/secure-client");
 
       expect(() => {
         new SecureClient({ baseURL: "http://proxy.example.com" });
-      }).toThrow("baseURL must use HTTPS");
+      }).not.toThrow();
     });
 
     it("should throw ConfigurationError when attestationBundleURL is not HTTPS", async () => {
@@ -470,14 +470,6 @@ describe("SecureClient", () => {
       expect(() => {
         new SecureClient({ baseURL: "https://proxy.example.com", transport: "tls" });
       }).toThrow("baseURL is only supported with the 'ehbp' transport");
-    });
-
-    it("should throw ConfigurationError for an empty baseURL instead of failing later", async () => {
-      const { SecureClient } = await import("../src/secure-client");
-
-      expect(() => {
-        new SecureClient({ baseURL: "" });
-      }).toThrow("baseURL must use HTTPS");
     });
 
     it("should throw ConfigurationError for an empty enclaveURL", async () => {

--- a/packages/tinfoil/test/secure-client.test.ts
+++ b/packages/tinfoil/test/secure-client.test.ts
@@ -26,21 +26,17 @@ const mockVerificationDocument = {
 };
 
 const verifyMock = vi.fn(async () => ({
-  tlsPublicKeyFingerprint: undefined,
+  tlsPublicKeyFingerprint: "mock-tls-public-key-fingerprint",
   hpkePublicKey: "mock-hpke-public-key",
   measurement: { type: MOCK_MEASUREMENT_TYPE, registers: [] },
 }));
 
 const mockFetch = vi.fn(async () => new Response(JSON.stringify({ message: "success" })));
 const mockGetSessionRecoveryToken = vi.fn(async () => ({ exportedSecret: new Uint8Array(), requestEnc: new Uint8Array() }));
-const createSecureFetchMock = vi.fn(
-  async (_baseURL: string, hpkePublicKey: string | undefined) => {
-    if (hpkePublicKey) {
-      return { fetch: mockFetch, getSessionRecoveryToken: mockGetSessionRecoveryToken };
-    }
-    throw new Error("TLS-only verification not supported in tests");
-  },
-);
+const createSecureFetchMock = vi.fn(async () => ({
+  fetch: mockFetch,
+  getSessionRecoveryToken: mockGetSessionRecoveryToken,
+}));
 
 vi.mock("../src/verifier.js", () => ({
   Verifier: class {
@@ -301,12 +297,14 @@ describe("SecureClient", () => {
       await client.ready();
       expect(client.getBaseURL()).toBe("https://test-router.tinfoil.sh/v1/");
       expect(client.getEnclaveURL()).toBe("https://test-router.tinfoil.sh");
+      expect(client.getEnclaveBaseURL()).toBe("https://test-router.tinfoil.sh/v1/");
 
       client.reset();
 
       // Derived state should be cleared
       expect(client.getBaseURL()).toBeUndefined();
       expect(client.getEnclaveURL()).toBeUndefined();
+      expect(client.getEnclaveBaseURL()).toBeUndefined();
 
       await client.ready();
 
@@ -464,12 +462,33 @@ describe("SecureClient", () => {
       }).toThrow("attestationBundleURL must use HTTPS");
     });
 
-    it("should throw ConfigurationError when baseURL is combined with the tls transport", async () => {
+    it("should allow TLS transport with a baseURL on the enclave origin", async () => {
       const { SecureClient } = await import("../src/secure-client");
 
-      expect(() => {
-        new SecureClient({ baseURL: "https://proxy.example.com", transport: "tls" });
-      }).toThrow("baseURL is only supported with the 'ehbp' transport");
+      const client = new SecureClient({
+        baseURL: "https://test-router.tinfoil.sh/custom/",
+        transport: "tls",
+      });
+      await expect(client.ready()).resolves.toBeUndefined();
+      expect(createSecureFetchMock).toHaveBeenCalledWith(
+        "https://test-router.tinfoil.sh/custom/",
+        undefined,
+        "mock-tls-public-key-fingerprint",
+        "https://test-router.tinfoil.sh",
+      );
+    });
+
+    it("should reject TLS transport with a proxy baseURL", async () => {
+      const { SecureClient } = await import("../src/secure-client");
+
+      const client = new SecureClient({
+        baseURL: "https://proxy.example.com",
+        transport: "tls",
+      });
+      await expect(client.ready()).rejects.toThrow(
+        "TLS transport requires baseURL to use the verified enclave origin",
+      );
+      expect(createSecureFetchMock).not.toHaveBeenCalled();
     });
 
     it("should throw ConfigurationError for an empty enclaveURL", async () => {

--- a/packages/tinfoil/test/secure-client.test.ts
+++ b/packages/tinfoil/test/secure-client.test.ts
@@ -454,6 +454,17 @@ describe("SecureClient", () => {
       }).not.toThrow();
     });
 
+    it.each(["", "not a URL", "ftp://proxy.example.com"])(
+      "should throw ConfigurationError for invalid baseURL %j",
+      async (baseURL) => {
+        const { SecureClient } = await import("../src/secure-client");
+
+        expect(() => {
+          new SecureClient({ baseURL });
+        }).toThrow("baseURL must be a valid HTTP(S) URL");
+      },
+    );
+
     it("should throw ConfigurationError when attestationBundleURL is not HTTPS", async () => {
       const { SecureClient } = await import("../src/secure-client");
 

--- a/packages/tinfoil/test/secure-client.websocket.test.ts
+++ b/packages/tinfoil/test/secure-client.websocket.test.ts
@@ -54,7 +54,7 @@ vi.mock("../src/pinned-ws.js", () => ({
 }));
 
 import { SecureClient } from "../src/secure-client.js";
-import { ConfigurationError, AttestationError } from "../src/verifier.js";
+import { AttestationError } from "../src/verifier.js";
 import { fetchAttestationBundle } from "../src/atc.js";
 
 beforeEach(() => {
@@ -89,17 +89,17 @@ describe("SecureClient.createWebSocket", () => {
     );
   });
 
-  it("rejects when a proxy baseURL is configured", async () => {
+  it("connects directly to the enclave when a proxy baseURL is configured", async () => {
     const client = new SecureClient({
       baseURL: "https://proxy.example.com/v1/",
     });
-    await expect(client.createWebSocket("/v1/realtime")).rejects.toThrow(
-      ConfigurationError,
+    await client.createWebSocket("/v1/realtime");
+
+    expect(createPinnedWebSocketMock).toHaveBeenCalledWith(
+      "wss://enclave.example.com/v1/realtime",
+      MOCK_FINGERPRINT,
+      undefined,
     );
-    await expect(client.createWebSocket("/v1/realtime")).rejects.toThrow(
-      /proxy baseURL/,
-    );
-    expect(createPinnedWebSocketMock).not.toHaveBeenCalled();
   });
 
   it("rejects absolute URLs pointing at another host", async () => {
@@ -149,12 +149,13 @@ describe("SecureClient.getPinnedWebSocketOptions", () => {
     expect(options).toEqual({ rejectUnauthorized: true });
   });
 
-  it("rejects when a proxy baseURL is configured", async () => {
+  it("returns pinned options when a proxy baseURL is configured", async () => {
     const client = new SecureClient({
       baseURL: "https://proxy.example.com/v1/",
     });
-    await expect(client.getPinnedWebSocketOptions()).rejects.toThrow(
-      ConfigurationError,
-    );
+    await expect(client.getPinnedWebSocketOptions()).resolves.toEqual({
+      rejectUnauthorized: true,
+    });
+    expect(pinnedWsClientOptionsMock).toHaveBeenCalledWith(MOCK_FINGERPRINT);
   });
 });


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Allow HTTP proxy URLs for `baseURL` in `tinfoil` and refine transport behavior. TLS and realtime now connect directly to the verified enclave; EHBP can use HTTP proxies.

- **Bug Fixes**
  - Removed HTTPS requirement for `baseURL` and key retrieval (`createEncryptedBodyFetch`/`getServerIdentity`) to support HTTP proxies.
  - Validate `baseURL` as a valid HTTP(S) URL; reject invalid/other protocols. Allow TLS with `baseURL` only when it uses the enclave origin; WebSocket/OpenAI Realtime always connect directly to the enclave.
  - Kept HTTPS validation for `enclaveURL` and `attestationBundleURL`; updated tests accordingly.

<sup>Written for commit d921a5428ed9e56b9754d799370b205219e16b5b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-js/pull/180?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

