### PR TITLE
chore: bump version to 1.1.8

### DIFF
--- a/packages/tinfoil/package.json
+++ b/packages/tinfoil/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tinfoil",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "description": "Tinfoil secure OpenAI client wrapper",
   "type": "module",
   "main": "dist/index.js",
@@ -63,7 +63,7 @@
   "dependencies": {
     "@ai-sdk/openai-compatible": "^2.0.41",
     "@freedomofpress/sigstore-browser": "^0.1.13",
-    "@tinfoilsh/verifier": "1.1.7",
+    "@tinfoilsh/verifier": "1.1.8",
     "@types/ws": "^8.18.1",
     "ehbp": "^0.2.0",
     "openai": "^6.34.0",

--- a/packages/verifier/package.json
+++ b/packages/verifier/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tinfoilsh/verifier",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "description": "AMD SEV-SNP attestation verifier for Node.js and browsers",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Prepare the 1.1.8 release. Bumps `tinfoil` and `@tinfoilsh/verifier` to 1.1.8 and aligns `tinfoil`’s dependency on `@tinfoilsh/verifier` to 1.1.8.

<sup>Written for commit 3ae20e9cd4cdd8a53914fa30d0e9811a99d286b4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-js/pull/181?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

