### PR TITLE
chore: release 1.1.10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3865,12 +3865,12 @@
       }
     },
     "packages/tinfoil": {
-      "version": "1.1.9",
+      "version": "1.1.10",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/openai-compatible": "^3.0.7",
         "@freedomofpress/sigstore-browser": "^0.1.14",
-        "@tinfoilsh/verifier": "1.1.9",
+        "@tinfoilsh/verifier": "1.1.10",
         "@types/ws": "^8.18.1",
         "ehbp": "^0.2.5",
         "openai": "^6.46.0",
@@ -3929,7 +3929,7 @@
     },
     "packages/verifier": {
       "name": "@tinfoilsh/verifier",
-      "version": "1.1.9",
+      "version": "1.1.10",
       "license": "Apache-2.0",
       "dependencies": {
         "@freedomofpress/crypto-browser": "^0.1.7",

--- a/packages/tinfoil/package.json
+++ b/packages/tinfoil/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tinfoil",
-  "version": "1.1.9",
+  "version": "1.1.10",
   "description": "Tinfoil secure OpenAI client wrapper",
   "type": "module",
   "main": "dist/index.js",
@@ -63,7 +63,7 @@
   "dependencies": {
     "@ai-sdk/openai-compatible": "^3.0.7",
     "@freedomofpress/sigstore-browser": "^0.1.14",
-    "@tinfoilsh/verifier": "1.1.9",
+    "@tinfoilsh/verifier": "1.1.10",
     "@types/ws": "^8.18.1",
     "ehbp": "^0.2.5",
     "openai": "^6.46.0",

--- a/packages/verifier/package.json
+++ b/packages/verifier/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tinfoilsh/verifier",
-  "version": "1.1.9",
+  "version": "1.1.10",
   "description": "AMD SEV-SNP attestation verifier for Node.js and browsers",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Prepare 1.1.10 release by bumping `tinfoil` and `@tinfoilsh/verifier` to 1.1.10 and aligning `tinfoil`’s dependency on `@tinfoilsh/verifier@1.1.10`. No functional changes.

<sup>Written for commit 58e6483a7f7e4853d56c6645af65ddb3d6e07058. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-js/pull/186?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

