### PR TITLE
Chore: bump EHBP 0.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3865,12 +3865,12 @@
       }
     },
     "packages/tinfoil": {
-      "version": "1.1.10",
+      "version": "1.1.11",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/openai-compatible": "^3.0.7",
         "@freedomofpress/sigstore-browser": "^0.1.14",
-        "@tinfoilsh/verifier": "1.1.10",
+        "@tinfoilsh/verifier": "1.1.11",
         "@types/ws": "^8.18.1",
         "ehbp": "^0.3.0",
         "openai": "^6.46.0",
@@ -3929,7 +3929,7 @@
     },
     "packages/verifier": {
       "name": "@tinfoilsh/verifier",
-      "version": "1.1.10",
+      "version": "1.1.11",
       "license": "Apache-2.0",
       "dependencies": {
         "@freedomofpress/crypto-browser": "^0.1.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@freedomofpress/crypto-browser": "^0.1.7",
         "@freedomofpress/sigstore-browser": "^0.1.14",
         "@freedomofpress/tuf-browser": "^0.1.11",
-        "ehbp": "^0.2.5"
+        "ehbp": "^0.3.0"
       },
       "devDependencies": {
         "acorn": "^8.16.0",
@@ -1777,9 +1777,9 @@
       }
     },
     "node_modules/ehbp": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/ehbp/-/ehbp-0.2.5.tgz",
-      "integrity": "sha512-Fjos3ct9f1Fxf2xckV+dXUez9vRa+k+pn3gqkivg0WaJ4WIQwXBCdT8iphr/+DmAQE9JKo4FdedwR3gwlA2kvA==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/ehbp/-/ehbp-0.3.0.tgz",
+      "integrity": "sha512-emLvsu3aeE1LXHvJASMXgJWxw9AuXVLPA4zkyujVwlqlfogBh9Gdd+tPH7nQJw5JfVwfZPU3W2oA5UuihMUIMg==",
       "license": "MIT",
       "dependencies": {
         "@panva/hpke-noble": "^1.0.3",
@@ -3872,7 +3872,7 @@
         "@freedomofpress/sigstore-browser": "^0.1.14",
         "@tinfoilsh/verifier": "1.1.10",
         "@types/ws": "^8.18.1",
-        "ehbp": "^0.2.5",
+        "ehbp": "^0.3.0",
         "openai": "^6.46.0",
         "ws": "^8.21.0"
       },

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@freedomofpress/crypto-browser": "^0.1.7",
     "@freedomofpress/sigstore-browser": "^0.1.14",
     "@freedomofpress/tuf-browser": "^0.1.11",
-    "ehbp": "^0.2.5"
+    "ehbp": "^0.3.0"
   },
   "syncpack": {
     "versionGroups": [

--- a/packages/tinfoil/package.json
+++ b/packages/tinfoil/package.json
@@ -65,7 +65,7 @@
     "@freedomofpress/sigstore-browser": "^0.1.14",
     "@tinfoilsh/verifier": "1.1.10",
     "@types/ws": "^8.18.1",
-    "ehbp": "^0.2.5",
+    "ehbp": "^0.3.0",
     "openai": "^6.46.0",
     "ws": "^8.21.0"
   },

--- a/packages/tinfoil/package.json
+++ b/packages/tinfoil/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tinfoil",
-  "version": "1.1.10",
+  "version": "1.1.11",
   "description": "Tinfoil secure OpenAI client wrapper",
   "type": "module",
   "main": "dist/index.js",
@@ -63,7 +63,7 @@
   "dependencies": {
     "@ai-sdk/openai-compatible": "^3.0.7",
     "@freedomofpress/sigstore-browser": "^0.1.14",
-    "@tinfoilsh/verifier": "1.1.10",
+    "@tinfoilsh/verifier": "1.1.11",
     "@types/ws": "^8.18.1",
     "ehbp": "^0.3.0",
     "openai": "^6.46.0",

--- a/packages/verifier/package.json
+++ b/packages/verifier/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tinfoilsh/verifier",
-  "version": "1.1.10",
+  "version": "1.1.11",
   "description": "AMD SEV-SNP attestation verifier for Node.js and browsers",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Bump `ehbp` from ^0.2.5 to ^0.3.0 across the repo and release `tinfoil` and `@tinfoilsh/verifier` as 1.1.11. No code changes beyond the version updates; lockfile refreshed.

<sup>Written for commit 60e659d44066e2da9db17032c58b3b69b8caefea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-js/pull/187?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

