### PR TITLE
fix: preserve secure request semantics

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@freedomofpress/crypto-browser": "^0.1.7",
         "@freedomofpress/sigstore-browser": "^0.1.14",
         "@freedomofpress/tuf-browser": "^0.1.11",
-        "ehbp": "^0.3.0"
+        "ehbp": "^0.3.1"
       },
       "devDependencies": {
         "acorn": "^8.16.0",
@@ -1777,9 +1777,9 @@
       }
     },
     "node_modules/ehbp": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/ehbp/-/ehbp-0.3.0.tgz",
-      "integrity": "sha512-emLvsu3aeE1LXHvJASMXgJWxw9AuXVLPA4zkyujVwlqlfogBh9Gdd+tPH7nQJw5JfVwfZPU3W2oA5UuihMUIMg==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/ehbp/-/ehbp-0.3.1.tgz",
+      "integrity": "sha512-Y0g5OWSBWis5rJgw3mEftnvJtW5vD+5LSuzYwAy39HlmMWHm6KFBtw+Wr50IrCKWyRVW2VdxkMMwA8yAnBmkag==",
       "license": "MIT",
       "dependencies": {
         "@panva/hpke-noble": "^1.0.3",
@@ -3872,7 +3872,7 @@
         "@freedomofpress/sigstore-browser": "^0.1.14",
         "@tinfoilsh/verifier": "1.1.11",
         "@types/ws": "^8.18.1",
-        "ehbp": "^0.3.0",
+        "ehbp": "^0.3.1",
         "openai": "^6.46.0",
         "ws": "^8.21.0"
       },

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@freedomofpress/crypto-browser": "^0.1.7",
     "@freedomofpress/sigstore-browser": "^0.1.14",
     "@freedomofpress/tuf-browser": "^0.1.11",
-    "ehbp": "^0.3.0"
+    "ehbp": "^0.3.1"
   },
   "syncpack": {
     "versionGroups": [

--- a/packages/tinfoil/package.json
+++ b/packages/tinfoil/package.json
@@ -65,7 +65,7 @@
     "@freedomofpress/sigstore-browser": "^0.1.14",
     "@tinfoilsh/verifier": "1.1.11",
     "@types/ws": "^8.18.1",
-    "ehbp": "^0.3.0",
+    "ehbp": "^0.3.1",
     "openai": "^6.46.0",
     "ws": "^8.21.0"
   },

--- a/packages/tinfoil/src/encrypted-body-fetch.ts
+++ b/packages/tinfoil/src/encrypted-body-fetch.ts
@@ -52,20 +52,46 @@ export function normalizeEncryptedBodyRequestArgs(
     return { url: input.toString(), init };
   }
 
-  const request = input as Request;
-  const cloned = request.clone();
-
-  const derivedInit: RequestInit = {
-    method: cloned.method,
-    headers: new Headers(cloned.headers),
-    body: cloned.body ?? undefined,
-    signal: cloned.signal,
-  };
+  const request = new Request(input as Request, init);
 
   return {
-    url: cloned.url,
-    init: { ...derivedInit, ...init },
+    url: request.url,
+    init: requestInitFromRequest(request),
   };
+}
+
+function requestInitFromRequest(
+  request: Request,
+  body: BodyInit | null = request.body,
+): RequestInit {
+  const requestWithExtensions = request as Request & {
+    duplex?: "half";
+    priority?: RequestPriority;
+  };
+  const derivedInit: RequestInit & {
+    duplex?: "half";
+    priority?: RequestPriority;
+  } = {
+    method: request.method,
+    headers: new Headers(request.headers),
+    body: body ?? undefined,
+    cache: request.cache,
+    credentials: request.credentials,
+    integrity: request.integrity,
+    keepalive: request.keepalive,
+    mode: request.mode,
+    redirect: request.redirect,
+    referrer: request.referrer,
+    referrerPolicy: request.referrerPolicy,
+    signal: request.signal,
+  };
+  if (requestWithExtensions.duplex !== undefined) {
+    derivedInit.duplex = requestWithExtensions.duplex;
+  }
+  if (requestWithExtensions.priority !== undefined) {
+    derivedInit.priority = requestWithExtensions.priority;
+  }
+  return derivedInit;
 }
 
 export async function encryptedBodyRequest(
@@ -139,7 +165,7 @@ export function createEncryptedBodyFetch(baseURL: string, hpkePublicKey: string,
       );
 
       const transportInstance = await getOrCreateTransport();
-      return encryptedBodyRequest(targetUrl.toString(), hpkePublicKey, initWithHeader, transportInstance);
+      return transportInstance.request(targetUrl.toString(), initWithHeader!);
     },
 
     async getSessionRecoveryToken(): Promise<SessionRecoveryToken> {

--- a/packages/tinfoil/test/encrypted-body-fetch.test.ts
+++ b/packages/tinfoil/test/encrypted-body-fetch.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { encryptedBodyRequest, normalizeEncryptedBodyRequestArgs, getServerIdentity, createEncryptedBodyFetch, createUnverifiedEncryptedBodyFetch } from "../src/encrypted-body-fetch";
-import { Identity, PROTOCOL } from "ehbp";
+import { Identity, KeyConfigMismatchError, PROTOCOL } from "ehbp";
 
 describe("encrypted-body-fetch", () => {
   describe("getServerIdentity", () => {
@@ -118,14 +118,19 @@ describe("encrypted-body-fetch", () => {
     it("merges init options with Request", () => {
       const request = new Request("https://example.com/test", {
         method: "POST",
+        credentials: "include",
+        redirect: "manual",
       });
 
       const result = normalizeEncryptedBodyRequestArgs(request, {
         headers: { "X-Custom": "header" },
+        credentials: "omit",
       });
 
       expect(result.url).toBe("https://example.com/test");
       expect(result.init?.headers).toBeTruthy();
+      expect(result.init?.credentials).toBe("omit");
+      expect(result.init?.redirect).toBe("manual");
     });
 
     it("handles string URLs with init options", () => {
@@ -149,6 +154,14 @@ describe("encrypted-body-fetch", () => {
       globalThis.fetch = originalFetch;
     });
 
+    function capturingTransport() {
+      const request = vi.fn(async () => new Response(null));
+      return {
+        request,
+        transport: { request } as unknown as import("ehbp").Transport,
+      };
+    }
+
     it("makes request with valid HPKE key", async () => {
       const serverIdentity = await Identity.generate();
       const keyHex = await serverIdentity.getPublicKeyHex();
@@ -169,6 +182,65 @@ describe("encrypted-body-fetch", () => {
 
       expect(apiRequestMade).toBe(true);
     });
+
+    it("passes through nonce-less errors after encrypted requests", async () => {
+      const serverIdentity = await Identity.generate();
+      const keyHex = await serverIdentity.getPublicKeyHex();
+      globalThis.fetch = vi.fn(async () => new Response("proxy rejected request", {
+        status: 502,
+        headers: {
+          "Content-Type": "text/plain",
+          "X-Proxy": "edge",
+        },
+      })) as typeof fetch;
+
+      const response = await encryptedBodyRequest(
+        "https://api.example.com/test",
+        keyHex,
+        { method: "POST", body: "secret" },
+      );
+
+      expect(response.status).toBe(502);
+      expect(response.headers.get("x-proxy")).toBe("edge");
+      await expect(response.text()).resolves.toBe("proxy rejected request");
+    });
+
+    it("inherits a Request body when init explicitly sets body to null", async () => {
+      const { request: requestSpy, transport } = capturingTransport();
+      const request = new Request("https://api.example.com/test", {
+        method: "POST",
+        body: "inherited body",
+      });
+
+      await encryptedBodyRequest(
+        request,
+        "",
+        { body: null },
+        transport,
+      );
+
+      const sentBody = requestSpy.mock.calls[0][1]!.body as BodyInit;
+      await expect(new Response(sentBody).text()).resolves.toBe("inherited body");
+    });
+
+    it("retains EHBP key mismatch errors", async () => {
+      const serverIdentity = await Identity.generate();
+      const keyHex = await serverIdentity.getPublicKeyHex();
+      globalThis.fetch = vi.fn(async () => new Response(JSON.stringify({
+        type: PROTOCOL.KEY_CONFIG_PROBLEM_TYPE,
+        title: "stale key",
+      }), {
+        status: 422,
+        headers: { "Content-Type": PROTOCOL.PROBLEM_JSON_MEDIA_TYPE },
+      })) as typeof fetch;
+
+      await expect(encryptedBodyRequest(
+        "https://api.example.com/test",
+        keyHex,
+        { method: "POST", body: "secret" },
+      )).rejects.toBeInstanceOf(KeyConfigMismatchError);
+    });
+
   });
 
   describe("createEncryptedBodyFetch", () => {
@@ -245,6 +317,65 @@ describe("encrypted-body-fetch", () => {
         await expect(
           transport.fetch("https://enclave.example.com/test")
         ).resolves.toBeInstanceOf(Response);
+      } finally {
+        globalThis.fetch = originalFetch;
+      }
+    });
+
+    it("preserves Request options and applies native init precedence", async () => {
+      const serverIdentity = await Identity.generate();
+      const keyHex = await serverIdentity.getPublicKeyHex();
+      const originalFetch = globalThis.fetch;
+      let sentRequest: Request | undefined;
+      globalThis.fetch = vi.fn(async (input: RequestInfo | URL) => {
+        sentRequest = input as Request;
+        return new Response("rejected", { status: 503 });
+      }) as typeof fetch;
+
+      try {
+        const request = new Request("https://api.example.com/test", {
+          method: "POST",
+          headers: { "X-Source": "request" },
+          body: "secret",
+          cache: "no-store",
+          credentials: "include",
+          integrity: "sha256-request",
+          keepalive: true,
+          mode: "cors",
+          redirect: "manual",
+          referrer: "https://referrer.example.com/source",
+          referrerPolicy: "origin",
+        });
+        const signal = new AbortController().signal;
+        const transport = createEncryptedBodyFetch("https://api.example.com", keyHex);
+
+        const response = await transport.fetch(request, {
+          method: "PUT",
+          headers: { "X-Source": "init" },
+          cache: "reload",
+          credentials: "omit",
+          integrity: "sha256-init",
+          keepalive: false,
+          mode: "same-origin",
+          redirect: "error",
+          referrer: "",
+          referrerPolicy: "no-referrer",
+          signal,
+        });
+
+        expect(response.status).toBe(503);
+        expect(sentRequest).toBeInstanceOf(Request);
+        expect(sentRequest?.method).toBe("PUT");
+        expect(sentRequest?.headers.get("x-source")).toBe("init");
+        expect(sentRequest?.cache).toBe("reload");
+        expect(sentRequest?.credentials).toBe("omit");
+        expect(sentRequest?.integrity).toBe("sha256-init");
+        expect(sentRequest?.keepalive).toBe(false);
+        expect(sentRequest?.mode).toBe("same-origin");
+        expect(sentRequest?.redirect).toBe("error");
+        expect(sentRequest?.referrer).toBe("");
+        expect(sentRequest?.referrerPolicy).toBe("no-referrer");
+        expect(sentRequest?.signal.aborted).toBe(false);
       } finally {
         globalThis.fetch = originalFetch;
       }


### PR DESCRIPTION
## Summary
- preserve native `Request` and `RequestInit` precedence, inherited bodies, and transport options without eagerly buffering request bodies
- resolve relative targets against the configured base URL and reject cross-origin requests before encryption
- retain focused regressions for request inheritance, origin binding, and EHBP key mismatches
- require and lock the released EHBP 0.3.1 package

## Validation
- `npm test`
- `npm run lint`
- `npm run build`
- `npm run check:es2020`

Coordinated with tinfoilsh/encrypted-http-body-protocol#83. The SDK version bump remains separate.