### PR TITLE
chore: release v1.1.12

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3865,12 +3865,12 @@
       }
     },
     "packages/tinfoil": {
-      "version": "1.1.11",
+      "version": "1.1.12",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/openai-compatible": "^3.0.7",
         "@freedomofpress/sigstore-browser": "^0.1.14",
-        "@tinfoilsh/verifier": "1.1.11",
+        "@tinfoilsh/verifier": "1.1.12",
         "@types/ws": "^8.18.1",
         "ehbp": "^0.3.1",
         "openai": "^6.46.0",
@@ -3929,7 +3929,7 @@
     },
     "packages/verifier": {
       "name": "@tinfoilsh/verifier",
-      "version": "1.1.11",
+      "version": "1.1.12",
       "license": "Apache-2.0",
       "dependencies": {
         "@freedomofpress/crypto-browser": "^0.1.7",

--- a/packages/tinfoil/package.json
+++ b/packages/tinfoil/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tinfoil",
-  "version": "1.1.11",
+  "version": "1.1.12",
   "description": "Tinfoil secure OpenAI client wrapper",
   "type": "module",
   "main": "dist/index.js",
@@ -63,7 +63,7 @@
   "dependencies": {
     "@ai-sdk/openai-compatible": "^3.0.7",
     "@freedomofpress/sigstore-browser": "^0.1.14",
-    "@tinfoilsh/verifier": "1.1.11",
+    "@tinfoilsh/verifier": "1.1.12",
     "@types/ws": "^8.18.1",
     "ehbp": "^0.3.1",
     "openai": "^6.46.0",

--- a/packages/verifier/package.json
+++ b/packages/verifier/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tinfoilsh/verifier",
-  "version": "1.1.11",
+  "version": "1.1.12",
   "description": "AMD SEV-SNP attestation verifier for Node.js and browsers",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
- bump `tinfoil` and `@tinfoilsh/verifier` to 1.1.12
- keep the internal verifier dependency and lockfile synchronized

## Validation
- `npm test`
- `npm run lint`
- `npm run build`
- `npm run check:es2020`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bump `tinfoil` and `@tinfoilsh/verifier` to 1.1.12. Sync `tinfoil`’s dependency on `@tinfoilsh/verifier` and update the lockfile to keep builds consistent.

<sup>Written for commit 6a7e248617afe16a3a2c62c841d88dce7ba6533b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-js/pull/189?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

