### PR TITLE
Silence expected browser cache warning

### DIFF
--- a/packages/tinfoil/src/user-cache-secret.ts
+++ b/packages/tinfoil/src/user-cache-secret.ts
@@ -82,15 +82,16 @@ function newUserCacheSecret(): string {
  * The process-lifetime fallback for when the secret cannot be persisted. When
  * secure random generation succeeds, an unpersisted secret still isolates
  * this process's cache namespace, but continuity is lost on restart — like a
- * session ID, it silently resets the namespace every deploy — so the fallback
- * warns once per process.
+ * session ID, it silently resets the namespace every deploy. The fallback
+ * warns once per process in server-side runtimes, where persistence is
+ * expected, but remains silent in browsers where in-memory storage is normal.
  */
 let ephemeralUserCacheSecret: string | undefined;
 
 function getEphemeralUserCacheSecret(): string {
   if (ephemeralUserCacheSecret === undefined) {
     ephemeralUserCacheSecret = newUserCacheSecret();
-    if (ephemeralUserCacheSecret !== "") {
+    if (ephemeralUserCacheSecret !== "" && !isRealBrowser()) {
       console.warn(
         "[tinfoil] could not persist the user cache secret; using an in-memory secret, " +
           "so prompt-cache continuity resets when this process exits " +

--- a/packages/tinfoil/test/user-cache-secret.browser.test.ts
+++ b/packages/tinfoil/test/user-cache-secret.browser.test.ts
@@ -1,0 +1,18 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { resolveUserCacheSecret } from "../src/user-cache-secret";
+
+describe("user cache secret (browser)", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("silently uses a stable in-memory secret", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const first = await resolveUserCacheSecret();
+
+    expect(first).toMatch(/^[0-9a-f]{64}$/);
+    await expect(resolveUserCacheSecret()).resolves.toBe(first);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- suppress the cache-secret persistence warning for the expected browser in-memory fallback
- retain the warning for server runtimes where persistence is expected
- verify browser secrets remain stable without emitting warnings

## Testing
- `npm test -w tinfoil -- test/user-cache-secret.test.ts`
- `npm run test:browser -w tinfoil -- test/user-cache-secret.browser.test.ts`
- `npm run lint -w tinfoil`
- `npm run build -w tinfoil`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Silences the user cache secret warning in browsers where in-memory storage is expected, while keeping the warning in server runtimes.

- **Bug Fixes**
  - Gate the warning behind `!isRealBrowser()` in `tinfoil`’s `user-cache-secret.ts`.
  - Add a browser test to verify the secret stays stable across calls and no warning is emitted.

<sup>Written for commit fab7ecec601b27ea226f60d03c9e8dd50db64975. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-js/pull/190?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

