### PR TITLE
Release v1.1.13 with EHBP v0.3.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@freedomofpress/crypto-browser": "^0.1.7",
         "@freedomofpress/sigstore-browser": "^0.1.14",
         "@freedomofpress/tuf-browser": "^0.1.11",
-        "ehbp": "^0.3.1"
+        "ehbp": "^0.3.2"
       },
       "devDependencies": {
         "acorn": "^8.16.0",
@@ -1777,9 +1777,9 @@
       }
     },
     "node_modules/ehbp": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/ehbp/-/ehbp-0.3.1.tgz",
-      "integrity": "sha512-Y0g5OWSBWis5rJgw3mEftnvJtW5vD+5LSuzYwAy39HlmMWHm6KFBtw+Wr50IrCKWyRVW2VdxkMMwA8yAnBmkag==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/ehbp/-/ehbp-0.3.2.tgz",
+      "integrity": "sha512-t6aIXrztsQC7jGypZ4Mvc7oMP2LN1q5zAWRKZUcVbgEZgXq/OoD9MAQGFOaCv5LMexx6BOKYpEfIhM/kaRMrtg==",
       "license": "MIT",
       "dependencies": {
         "@panva/hpke-noble": "^1.0.3",
@@ -3865,14 +3865,14 @@
       }
     },
     "packages/tinfoil": {
-      "version": "1.1.12",
+      "version": "1.1.13",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/openai-compatible": "^3.0.7",
         "@freedomofpress/sigstore-browser": "^0.1.14",
-        "@tinfoilsh/verifier": "1.1.12",
+        "@tinfoilsh/verifier": "1.1.13",
         "@types/ws": "^8.18.1",
-        "ehbp": "^0.3.1",
+        "ehbp": "^0.3.2",
         "openai": "^6.46.0",
         "ws": "^8.21.0"
       },
@@ -3929,7 +3929,7 @@
     },
     "packages/verifier": {
       "name": "@tinfoilsh/verifier",
-      "version": "1.1.12",
+      "version": "1.1.13",
       "license": "Apache-2.0",
       "dependencies": {
         "@freedomofpress/crypto-browser": "^0.1.7",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@freedomofpress/crypto-browser": "^0.1.7",
     "@freedomofpress/sigstore-browser": "^0.1.14",
     "@freedomofpress/tuf-browser": "^0.1.11",
-    "ehbp": "^0.3.1"
+    "ehbp": "^0.3.2"
   },
   "syncpack": {
     "versionGroups": [

--- a/packages/tinfoil/package.json
+++ b/packages/tinfoil/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tinfoil",
-  "version": "1.1.12",
+  "version": "1.1.13",
   "description": "Tinfoil secure OpenAI client wrapper",
   "type": "module",
   "main": "dist/index.js",
@@ -63,9 +63,9 @@
   "dependencies": {
     "@ai-sdk/openai-compatible": "^3.0.7",
     "@freedomofpress/sigstore-browser": "^0.1.14",
-    "@tinfoilsh/verifier": "1.1.12",
+    "@tinfoilsh/verifier": "1.1.13",
     "@types/ws": "^8.18.1",
-    "ehbp": "^0.3.1",
+    "ehbp": "^0.3.2",
     "openai": "^6.46.0",
     "ws": "^8.21.0"
   },

--- a/packages/verifier/package.json
+++ b/packages/verifier/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tinfoilsh/verifier",
-  "version": "1.1.12",
+  "version": "1.1.13",
   "description": "AMD SEV-SNP attestation verifier for Node.js and browsers",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
- bump `tinfoil` and `@tinfoilsh/verifier` to v1.1.13
- update the EHBP dependency and lockfile to v0.3.2
- include the Firefox request-body fix from EHBP v0.3.2

## Testing
- `npm run lint`
- `npm test`
- `npm run build`
- `npm run check:es2020`
- `npm run test:browser`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release v1.1.13 updates `tinfoil` and `@tinfoilsh/verifier`, and bumps `ehbp` to v0.3.2. Improves Firefox compatibility.

- **Dependencies**
  - Bumped `ehbp` to `^0.3.2`.
  - Updated `tinfoil` to `1.1.13`.
  - Updated `@tinfoilsh/verifier` to `1.1.13`.

- **Bug Fixes**
  - Fixes Firefox request-body handling via `ehbp` v0.3.2.

<sup>Written for commit 44da8518cf33e73774201f758557a7df7da4023b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-js/pull/191?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

