### PR TITLE
Expose verification provenance metadata

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Test
+        run: npm test
+
       - name: Build
         run: npm run build
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -3865,12 +3865,12 @@
       }
     },
     "packages/tinfoil": {
-      "version": "1.1.13",
+      "version": "1.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/openai-compatible": "^3.0.7",
         "@freedomofpress/sigstore-browser": "^0.1.14",
-        "@tinfoilsh/verifier": "1.1.13",
+        "@tinfoilsh/verifier": "1.2.0",
         "@types/ws": "^8.18.1",
         "ehbp": "^0.3.2",
         "openai": "^6.46.0",
@@ -3929,7 +3929,7 @@
     },
     "packages/verifier": {
       "name": "@tinfoilsh/verifier",
-      "version": "1.1.13",
+      "version": "1.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@freedomofpress/crypto-browser": "^0.1.7",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "lint": "npm run lint -w tinfoil",
     "test": "npm run test -ws --if-present",
     "test:integration": "npm run test:integration -ws --if-present",
-    "test:browser": "npm run test:browser -ws --if-present",
+    "test:browser": "npm run build -w @tinfoilsh/verifier && npm run test:browser -ws --if-present",
     "test:browser:integration": "npm run test:browser:integration -ws --if-present",
     "test:all": "npm run test && npm run test:integration && npm run test:browser && npm run test:browser:integration",
     "check:es2020": "npm run check:es2020 -ws --if-present",

--- a/packages/tinfoil/package.json
+++ b/packages/tinfoil/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tinfoil",
-  "version": "1.1.13",
+  "version": "1.2.0",
   "description": "Tinfoil secure OpenAI client wrapper",
   "type": "module",
   "main": "dist/index.js",
@@ -63,7 +63,7 @@
   "dependencies": {
     "@ai-sdk/openai-compatible": "^3.0.7",
     "@freedomofpress/sigstore-browser": "^0.1.14",
-    "@tinfoilsh/verifier": "1.1.13",
+    "@tinfoilsh/verifier": "1.2.0",
     "@types/ws": "^8.18.1",
     "ehbp": "^0.3.2",
     "openai": "^6.46.0",

--- a/packages/tinfoil/src/atc.ts
+++ b/packages/tinfoil/src/atc.ts
@@ -50,6 +50,7 @@ export async function fetchAttestationBundle(options: FetchAttestationBundleOpti
       body: bundle.enclaveAttestationReport.body,
     },
     digest: bundle.digest,
+    releaseTag: bundle.releaseTag,
     sigstoreBundle: bundle.sigstoreBundle,
     vcek: bundle.vcek,
     enclaveCert: bundle.enclaveCert,

--- a/packages/tinfoil/src/secure-client.ts
+++ b/packages/tinfoil/src/secure-client.ts
@@ -1,6 +1,6 @@
 import { KeyConfigMismatchError } from "ehbp";
-import { cloneJsonSnapshot, VERIFICATION_DOCUMENT_SCHEMA_VERSION, VERIFIER_NAME, VERIFIER_VERSION } from "@tinfoilsh/verifier";
-import { Verifier, ConfigurationError, FetchError, AttestationError, type VerificationDocument } from "./verifier.js";
+import { VERIFICATION_DOCUMENT_SCHEMA_VERSION, VERIFIER_NAME, VERIFIER_VERSION } from "@tinfoilsh/verifier";
+import { cloneVerificationDocument, Verifier, ConfigurationError, FetchError, AttestationError, type VerificationDocument } from "./verifier.js";
 import type { AttestationBundle } from "./verifier.js";
 import { TINFOIL_CONFIG } from "./config.js";
 import { createSecureFetch } from "./secure-fetch.js";
@@ -308,7 +308,7 @@ export class SecureClient {
    * @see https://docs.tinfoil.sh/verification/attestation-architecture
    */
   public getVerificationDocument(): VerificationDocument {
-    return cloneJsonSnapshot(this.verificationDocument);
+    return cloneVerificationDocument(this.verificationDocument);
   }
 
   /**

--- a/packages/tinfoil/src/secure-client.ts
+++ b/packages/tinfoil/src/secure-client.ts
@@ -1,4 +1,5 @@
 import { KeyConfigMismatchError } from "ehbp";
+import { VERIFIER_NAME, VERIFIER_VERSION } from "@tinfoilsh/verifier";
 import { Verifier, ConfigurationError, FetchError, AttestationError, type VerificationDocument } from "./verifier.js";
 import type { AttestationBundle } from "./verifier.js";
 import { TINFOIL_CONFIG } from "./config.js";
@@ -78,6 +79,7 @@ export interface SecureClientOptions {
 
 function createPendingVerificationDocument(configRepo: string): VerificationDocument {
   return {
+    schemaVersion: 1,
     configRepo,
     enclaveHost: '',
     releaseDigest: '',
@@ -89,6 +91,10 @@ function createPendingVerificationDocument(configRepo: string): VerificationDocu
     enclaveFingerprint: '',
     selectedRouterEndpoint: '',
     securityVerified: false,
+    verifier: {
+      name: VERIFIER_NAME,
+      version: VERIFIER_VERSION,
+    },
     steps: {
       fetchDigest: { status: 'pending' },
       verifyCode: { status: 'pending' },

--- a/packages/tinfoil/src/secure-client.ts
+++ b/packages/tinfoil/src/secure-client.ts
@@ -1,5 +1,5 @@
 import { KeyConfigMismatchError } from "ehbp";
-import { VERIFIER_NAME, VERIFIER_VERSION } from "@tinfoilsh/verifier";
+import { VERIFICATION_DOCUMENT_SCHEMA_VERSION, VERIFIER_NAME, VERIFIER_VERSION } from "@tinfoilsh/verifier";
 import { Verifier, ConfigurationError, FetchError, AttestationError, type VerificationDocument } from "./verifier.js";
 import type { AttestationBundle } from "./verifier.js";
 import { TINFOIL_CONFIG } from "./config.js";
@@ -79,7 +79,7 @@ export interface SecureClientOptions {
 
 function createPendingVerificationDocument(configRepo: string): VerificationDocument {
   return {
-    schemaVersion: 1,
+    schemaVersion: VERIFICATION_DOCUMENT_SCHEMA_VERSION,
     configRepo,
     enclaveHost: '',
     releaseDigest: '',

--- a/packages/tinfoil/src/secure-client.ts
+++ b/packages/tinfoil/src/secure-client.ts
@@ -1,5 +1,5 @@
 import { KeyConfigMismatchError } from "ehbp";
-import { VERIFICATION_DOCUMENT_SCHEMA_VERSION, VERIFIER_NAME, VERIFIER_VERSION } from "@tinfoilsh/verifier";
+import { cloneJsonSnapshot, VERIFICATION_DOCUMENT_SCHEMA_VERSION, VERIFIER_NAME, VERIFIER_VERSION } from "@tinfoilsh/verifier";
 import { Verifier, ConfigurationError, FetchError, AttestationError, type VerificationDocument } from "./verifier.js";
 import type { AttestationBundle } from "./verifier.js";
 import { TINFOIL_CONFIG } from "./config.js";
@@ -308,7 +308,7 @@ export class SecureClient {
    * @see https://docs.tinfoil.sh/verification/attestation-architecture
    */
   public getVerificationDocument(): VerificationDocument {
-    return this.verificationDocument;
+    return cloneJsonSnapshot(this.verificationDocument);
   }
 
   /**

--- a/packages/tinfoil/test/atc.test.ts
+++ b/packages/tinfoil/test/atc.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { X509Certificate } from "@freedomofpress/sigstore-browser";
 
 const RUN_INTEGRATION = process.env.RUN_TINFOIL_INTEGRATION === "true";
@@ -100,6 +100,30 @@ describe("ATC API", () => {
       await expect(fetchAttestationBundle({ atcBaseUrl: "http://atc.example.com" })).rejects.toThrow(
         /must use HTTPS/
       );
+    });
+
+    it("should preserve the selected release tag", async () => {
+      const responseBundle = {
+        domain: "router.example.com",
+        enclaveAttestationReport: { format: "test", body: "report" },
+        digest: "digest",
+        releaseTag: "v1.2.3",
+        sigstoreBundle: {},
+        vcek: "vcek",
+        enclaveCert: "certificate",
+      };
+      const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(JSON.stringify(responseBundle)),
+      );
+      const { fetchAttestationBundle } = await import("../src/atc");
+
+      try {
+        const bundle = await fetchAttestationBundle({ atcBaseUrl: "https://atc.example.com" });
+
+        expect(bundle.releaseTag).toBe(responseBundle.releaseTag);
+      } finally {
+        fetchMock.mockRestore();
+      }
     });
   });
 

--- a/packages/tinfoil/test/secure-client.browser.test.ts
+++ b/packages/tinfoil/test/secure-client.browser.test.ts
@@ -28,6 +28,7 @@ const mockVerificationDocument = {
 };
 
 vi.mock("../src/verifier.js", () => ({
+  cloneVerificationDocument: (document: typeof mockVerificationDocument) => structuredClone(document),
   Verifier: class {
     verify() {
       return verifyMock();

--- a/packages/tinfoil/test/secure-client.test.ts
+++ b/packages/tinfoil/test/secure-client.test.ts
@@ -52,6 +52,7 @@ const createSecureFetchMock = vi.fn<
 }));
 
 vi.mock("../src/verifier.js", () => ({
+  cloneVerificationDocument: (document: typeof mockVerificationDocument) => structuredClone(document),
   Verifier: class {
     verify() {
       return verifyMock();
@@ -215,7 +216,7 @@ describe("SecureClient", () => {
     const client = new SecureClient({ baseURL: "https://test.example.com/" });
 
     await client.ready();
-    const original = client.getVerificationDocument();
+    const expected = structuredClone(mockVerificationDocument);
     const snapshot = client.getVerificationDocument();
     snapshot.securityVerified = false;
     snapshot.releaseTag = "modified";
@@ -224,7 +225,7 @@ describe("SecureClient", () => {
     snapshot.codeMeasurement.registers.push("modified");
     snapshot.enclaveMeasurement.measurement.registers.push("modified");
 
-    expect(client.getVerificationDocument()).toEqual(original);
+    expect(client.getVerificationDocument()).toEqual(expected);
   });
 
   it("should lazily initialize when fetch is first accessed", async () => {

--- a/packages/tinfoil/test/secure-client.test.ts
+++ b/packages/tinfoil/test/secure-client.test.ts
@@ -7,6 +7,7 @@ const MOCK_MEASUREMENT_TYPE = "https://tinfoil.sh/predicate/sev-snp-guest/v1";
 const mockVerificationDocument = {
   configRepo: "test-repo",
   enclaveHost: "test-host",
+  releaseTag: "test-release",
   releaseDigest: "test-digest",
   codeMeasurement: { type: MOCK_MEASUREMENT_TYPE, registers: [] },
   enclaveMeasurement: {
@@ -19,6 +20,7 @@ const mockVerificationDocument = {
   enclaveFingerprint: "test-enclave-fingerprint",
   selectedRouterEndpoint: "test.example.com",
   securityVerified: true,
+  verifier: { name: "@tinfoilsh/verifier", version: "1.2.0" },
   steps: {
     fetchDigest: { status: "success" },
     verifyCode: { status: "success" },
@@ -32,6 +34,7 @@ const verifyMock = vi.fn(async () => ({
   hpkePublicKey: "mock-hpke-public-key",
   measurement: { type: MOCK_MEASUREMENT_TYPE, registers: [] },
 }));
+const getVerificationDocumentMock = vi.fn(() => mockVerificationDocument);
 
 const mockFetch = vi.fn(async () => new Response(JSON.stringify({ message: "success" })));
 const mockGetSessionRecoveryToken = vi.fn(async () => ({ exportedSecret: new Uint8Array(), requestEnc: new Uint8Array() }));
@@ -57,7 +60,7 @@ vi.mock("../src/verifier.js", () => ({
       return verifyMock();
     }
     getVerificationDocument() {
-      return mockVerificationDocument;
+      return getVerificationDocumentMock();
     }
   },
   FetchError: class FetchError extends Error {
@@ -205,6 +208,23 @@ describe("SecureClient", () => {
 
     expect(verifyMock).toHaveBeenCalledTimes(1);
     expect(verificationDocument).toEqual(mockVerificationDocument);
+  });
+
+  it("should return deeply cloned verification document snapshots", async () => {
+    const { SecureClient } = await import("../src/secure-client");
+    const client = new SecureClient({ baseURL: "https://test.example.com/" });
+
+    await client.ready();
+    const original = client.getVerificationDocument();
+    const snapshot = client.getVerificationDocument();
+    snapshot.securityVerified = false;
+    snapshot.releaseTag = "modified";
+    snapshot.verifier!.name = "modified";
+    snapshot.steps.verifyCode.status = "failed";
+    snapshot.codeMeasurement.registers.push("modified");
+    snapshot.enclaveMeasurement.measurement.registers.push("modified");
+
+    expect(client.getVerificationDocument()).toEqual(original);
   });
 
   it("should lazily initialize when fetch is first accessed", async () => {
@@ -628,6 +648,41 @@ describe("SecureClient", () => {
       expect(verifyMock).toHaveBeenCalledTimes(2);
       expect(createSecureFetchMock).toHaveBeenCalledTimes(2);
       expect(await response.json()).toEqual({ ok: true });
+    });
+
+    it("should replace verification metadata after automatic re-attestation", async () => {
+      const firstDocument = {
+        ...mockVerificationDocument,
+        releaseTag: "v1.0.0",
+        verifiedAt: "2026-01-01T00:00:00.000Z",
+      };
+      const replacementDocument = {
+        ...mockVerificationDocument,
+        releaseTag: "v1.1.0",
+        verifiedAt: "2026-02-01T00:00:00.000Z",
+      };
+      getVerificationDocumentMock
+        .mockReturnValueOnce(firstDocument)
+        .mockReturnValueOnce(replacementDocument);
+      const { KeyConfigMismatchError } = await import("ehbp");
+      mockFetch
+        .mockRejectedValueOnce(new KeyConfigMismatchError("Key config mismatch"))
+        .mockResolvedValueOnce(new Response(JSON.stringify({ ok: true })));
+      const { SecureClient } = await import("../src/secure-client");
+      const client = new SecureClient({ baseURL: "https://test.example.com/" });
+
+      await client.ready();
+      expect(client.getVerificationDocument()).toMatchObject({
+        releaseTag: firstDocument.releaseTag,
+        verifiedAt: firstDocument.verifiedAt,
+      });
+
+      await client.fetch("/test", { method: "GET" });
+
+      expect(client.getVerificationDocument()).toMatchObject({
+        releaseTag: replacementDocument.releaseTag,
+        verifiedAt: replacementDocument.verifiedAt,
+      });
     });
 
     it("should retry eligible requests with the injected cache secret", async () => {

--- a/packages/verifier/README.md
+++ b/packages/verifier/README.md
@@ -82,7 +82,26 @@ console.log(doc.steps.compareMeasurements); // Compared code vs enclave measurem
 // Measurements
 console.log(doc.codeFingerprint);     // Expected measurement from signed release
 console.log(doc.enclaveFingerprint);  // Actual measurement from enclave
+console.log(doc.releaseTag);          // GitHub release selected for verification
+console.log(doc.verifier);            // Verifier package identity and version
+console.log(doc.verifiedAt);           // Local completion time, not evidence freshness
 ```
+
+### Using Your Own Transport
+
+`Verifier` does not require callers to use the main SDK transport. After
+verification, `tlsPublicKeyFingerprint` contains the attested SHA-256 SPKI
+fingerprint and can be passed to a separate HTTP implementation:
+
+```typescript
+const attestation = await verifier.verify();
+const expectedSpkiFingerprint = attestation.tlsPublicKeyFingerprint;
+```
+
+The custom transport must compare that value with the live peer certificate's
+SPKI on every new TLS connection and must still perform normal hostname and
+certificate validation. Merely obtaining the fingerprint does not pin the
+connection.
 
 ## What Gets Verified
 

--- a/packages/verifier/package.json
+++ b/packages/verifier/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tinfoilsh/verifier",
-  "version": "1.1.13",
+  "version": "1.2.0",
   "description": "AMD SEV-SNP attestation verifier for Node.js and browsers",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/verifier/src/bundle.ts
+++ b/packages/verifier/src/bundle.ts
@@ -27,14 +27,15 @@ export async function assembleAttestationBundle(
 ): Promise<AttestationBundle> {
 
   // 1. Fetch independent resources in parallel
-  const [attestation, digest, enclaveCert] = await Promise.all([
+  const [attestation, release, enclaveCert] = await Promise.all([
     withRetry(async (): Promise<AttestationDocument> => {
       const doc = await fetchJson(`https://${enclaveHost}/.well-known/tinfoil-attestation`);
       return { format: doc.format as PredicateType, body: doc.body };
     }),
     withRetry(async () => {
       const { tag_name } = await fetchJson(`${GITHUB_PROXY}/repos/${configRepo}/releases/latest`);
-      return (await fetchText(`${GITHUB_PROXY}/${configRepo}/releases/download/${tag_name}/tinfoil.hash`)).trim();
+      const digest = (await fetchText(`${GITHUB_PROXY}/${configRepo}/releases/download/${tag_name}/tinfoil.hash`)).trim();
+      return { tag: tag_name as string, digest };
     }),
     withRetry(async () => {
       const data = await fetchJson(`https://${enclaveHost}/.well-known/tinfoil-certificate`);
@@ -44,9 +45,9 @@ export async function assembleAttestationBundle(
 
   // 2. Fetch Sigstore bundle (needs digest)
   const sigstoreBundle = await withRetry(async () => {
-    const data = await fetchJson(`${GITHUB_PROXY}/repos/${configRepo}/attestations/sha256:${digest}`);
+    const data = await fetchJson(`${GITHUB_PROXY}/repos/${configRepo}/attestations/sha256:${release.digest}`);
     if (!data.attestations?.[0]?.bundle) {
-      throw new FetchError(`No Sigstore bundle for ${configRepo} at digest ${digest}`);
+      throw new FetchError(`No Sigstore bundle for ${configRepo} at digest ${release.digest}`);
     }
     return data.attestations[0].bundle;
   });
@@ -74,7 +75,8 @@ export async function assembleAttestationBundle(
   return {
     domain: enclaveHost,
     enclaveAttestationReport: attestation,
-    digest,
+    digest: release.digest,
+    releaseTag: release.tag,
     sigstoreBundle,
     vcek,
     enclaveCert,

--- a/packages/verifier/src/bundle.ts
+++ b/packages/verifier/src/bundle.ts
@@ -76,6 +76,7 @@ export async function assembleAttestationBundle(
     domain: enclaveHost,
     enclaveAttestationReport: attestation,
     digest: release.digest,
+    releaseTag: release.tag,
     sigstoreBundle,
     vcek,
     enclaveCert,

--- a/packages/verifier/src/bundle.ts
+++ b/packages/verifier/src/bundle.ts
@@ -76,7 +76,6 @@ export async function assembleAttestationBundle(
     domain: enclaveHost,
     enclaveAttestationReport: attestation,
     digest: release.digest,
-    releaseTag: release.tag,
     sigstoreBundle,
     vcek,
     enclaveCert,

--- a/packages/verifier/src/client.ts
+++ b/packages/verifier/src/client.ts
@@ -5,6 +5,12 @@ import { verifyCertificate } from './cert-verify.js';
 import { compareMeasurements, measurementFingerprint } from './types.js';
 import type { AttestationResponse, VerificationDocument, AttestationBundle } from './types.js';
 import { ConfigurationError } from './errors.js';
+import { VERIFIER_NAME, VERIFIER_VERSION } from './version.js';
+
+const VERIFIER_IDENTITY = {
+  name: VERIFIER_NAME,
+  version: VERIFIER_VERSION,
+} as const;
 
 export interface VerifierOptions {
   /** Server URL for fetching attestation. Required when using verify(), optional when using verifyBundle(). */
@@ -31,7 +37,14 @@ export class Verifier {
     }
     const domain = new URL(this.serverURL).hostname;
     const bundle = await assembleAttestationBundle(domain, this.configRepo);
-    return this.verifyBundle(bundle);
+    const verification = await this.verifyBundle(bundle);
+    if (this.verificationDocument?.securityVerified) {
+      this.verificationDocument = {
+        ...this.verificationDocument,
+        releaseTag: bundle.releaseTag,
+      };
+    }
+    return verification;
   }
 
   async verifyBundle(bundle: AttestationBundle): Promise<AttestationResponse> {
@@ -95,6 +108,7 @@ export class Verifier {
 
       // Build successful verification document
       this.verificationDocument = {
+        schemaVersion: 1,
         configRepo: this.configRepo,
         enclaveHost: domain,
         releaseDigest: digest,
@@ -106,6 +120,8 @@ export class Verifier {
         enclaveFingerprint: await measurementFingerprint(amdVerification.measurement),
         selectedRouterEndpoint: domain,
         securityVerified: true,
+        verifier: VERIFIER_IDENTITY,
+        verifiedAt: new Date().toISOString(),
         steps
       };
 
@@ -120,6 +136,7 @@ export class Verifier {
 
   private saveFailedVerificationDocument(steps: VerificationDocument['steps'], domain: string): void {
     this.verificationDocument = {
+      schemaVersion: 1,
       configRepo: this.configRepo,
       enclaveHost: domain,
       releaseDigest: '',
@@ -131,6 +148,7 @@ export class Verifier {
       enclaveFingerprint: '',
       selectedRouterEndpoint: domain,
       securityVerified: false,
+      verifier: VERIFIER_IDENTITY,
       steps
     };
   }

--- a/packages/verifier/src/client.ts
+++ b/packages/verifier/src/client.ts
@@ -5,6 +5,7 @@ import { verifyCertificate } from './cert-verify.js';
 import { compareMeasurements, measurementFingerprint } from './types.js';
 import type { AttestationResponse, VerificationDocument, AttestationBundle, SoftwareIdentity } from './types.js';
 import { ConfigurationError } from './errors.js';
+import { cloneJsonSnapshot } from './json.js';
 import { VERIFICATION_DOCUMENT_SCHEMA_VERSION, VERIFIER_NAME, VERIFIER_VERSION } from './version.js';
 
 function verifierIdentity(): SoftwareIdentity {
@@ -155,6 +156,8 @@ export class Verifier {
   }
 
   getVerificationDocument(): VerificationDocument | undefined {
-    return this.verificationDocument;
+    return this.verificationDocument
+      ? cloneJsonSnapshot(this.verificationDocument)
+      : undefined;
   }
 }

--- a/packages/verifier/src/client.ts
+++ b/packages/verifier/src/client.ts
@@ -5,7 +5,7 @@ import { verifyCertificate } from './cert-verify.js';
 import { compareMeasurements, measurementFingerprint } from './types.js';
 import type { AttestationResponse, VerificationDocument, AttestationBundle, SoftwareIdentity } from './types.js';
 import { ConfigurationError } from './errors.js';
-import { cloneJsonSnapshot } from './json.js';
+import { cloneVerificationDocument } from './json.js';
 import { VERIFICATION_DOCUMENT_SCHEMA_VERSION, VERIFIER_NAME, VERIFIER_VERSION } from './version.js';
 
 function verifierIdentity(): SoftwareIdentity {
@@ -157,7 +157,7 @@ export class Verifier {
 
   getVerificationDocument(): VerificationDocument | undefined {
     return this.verificationDocument
-      ? cloneJsonSnapshot(this.verificationDocument)
+      ? cloneVerificationDocument(this.verificationDocument)
       : undefined;
   }
 }

--- a/packages/verifier/src/client.ts
+++ b/packages/verifier/src/client.ts
@@ -5,12 +5,12 @@ import { verifyCertificate } from './cert-verify.js';
 import { compareMeasurements, measurementFingerprint } from './types.js';
 import type { AttestationResponse, VerificationDocument, AttestationBundle } from './types.js';
 import { ConfigurationError } from './errors.js';
-import { VERIFIER_NAME, VERIFIER_VERSION } from './version.js';
+import { VERIFICATION_DOCUMENT_SCHEMA_VERSION, VERIFIER_NAME, VERIFIER_VERSION } from './version.js';
 
-const VERIFIER_IDENTITY = {
+const VERIFIER_IDENTITY = Object.freeze({
   name: VERIFIER_NAME,
   version: VERIFIER_VERSION,
-} as const;
+} as const);
 
 export interface VerifierOptions {
   /** Server URL for fetching attestation. Required when using verify(), optional when using verifyBundle(). */
@@ -37,14 +37,7 @@ export class Verifier {
     }
     const domain = new URL(this.serverURL).hostname;
     const bundle = await assembleAttestationBundle(domain, this.configRepo);
-    const verification = await this.verifyBundle(bundle);
-    if (this.verificationDocument?.securityVerified) {
-      this.verificationDocument = {
-        ...this.verificationDocument,
-        releaseTag: bundle.releaseTag,
-      };
-    }
-    return verification;
+    return this.verifyBundle(bundle);
   }
 
   async verifyBundle(bundle: AttestationBundle): Promise<AttestationResponse> {
@@ -72,8 +65,11 @@ export class Verifier {
 
       // Step 2: Verify code provenance (Sigstore bundle)
       let codeMeasurements;
+      let releaseTag: string;
       try {
-        codeMeasurements = await verifySigstoreBundle(sigstoreBundle, digest, this.configRepo);
+        const verifiedCode = await verifySigstoreBundle(sigstoreBundle, digest, this.configRepo);
+        codeMeasurements = verifiedCode.measurement;
+        releaseTag = verifiedCode.releaseTag;
         steps.verifyCode = { status: 'success' };
       } catch (error) {
         steps.verifyCode = { status: 'failed', error: (error as Error).message };
@@ -108,9 +104,10 @@ export class Verifier {
 
       // Build successful verification document
       this.verificationDocument = {
-        schemaVersion: 1,
+        schemaVersion: VERIFICATION_DOCUMENT_SCHEMA_VERSION,
         configRepo: this.configRepo,
         enclaveHost: domain,
+        releaseTag,
         releaseDigest: digest,
         codeMeasurement: codeMeasurements,
         enclaveMeasurement: amdVerification,
@@ -136,7 +133,7 @@ export class Verifier {
 
   private saveFailedVerificationDocument(steps: VerificationDocument['steps'], domain: string): void {
     this.verificationDocument = {
-      schemaVersion: 1,
+      schemaVersion: VERIFICATION_DOCUMENT_SCHEMA_VERSION,
       configRepo: this.configRepo,
       enclaveHost: domain,
       releaseDigest: '',

--- a/packages/verifier/src/client.ts
+++ b/packages/verifier/src/client.ts
@@ -3,14 +3,13 @@ import { verifySigstoreBundle } from './sigstore.js';
 import { assembleAttestationBundle } from './bundle.js';
 import { verifyCertificate } from './cert-verify.js';
 import { compareMeasurements, measurementFingerprint } from './types.js';
-import type { AttestationResponse, VerificationDocument, AttestationBundle } from './types.js';
+import type { AttestationResponse, VerificationDocument, AttestationBundle, SoftwareIdentity } from './types.js';
 import { ConfigurationError } from './errors.js';
 import { VERIFICATION_DOCUMENT_SCHEMA_VERSION, VERIFIER_NAME, VERIFIER_VERSION } from './version.js';
 
-const VERIFIER_IDENTITY = Object.freeze({
-  name: VERIFIER_NAME,
-  version: VERIFIER_VERSION,
-} as const);
+function verifierIdentity(): SoftwareIdentity {
+  return { name: VERIFIER_NAME, version: VERIFIER_VERSION };
+}
 
 export interface VerifierOptions {
   /** Server URL for fetching attestation. Required when using verify(), optional when using verifyBundle(). */
@@ -41,7 +40,7 @@ export class Verifier {
   }
 
   async verifyBundle(bundle: AttestationBundle): Promise<AttestationResponse> {
-    const { enclaveAttestationReport: attestationDoc, vcek, digest, sigstoreBundle, domain, enclaveCert } = bundle;
+    const { enclaveAttestationReport: attestationDoc, vcek, digest, releaseTag: selectedReleaseTag, sigstoreBundle, domain, enclaveCert } = bundle;
 
     const steps: VerificationDocument['steps'] = {
       fetchDigest: { status: 'success' }, // Already fetched by caller
@@ -67,7 +66,12 @@ export class Verifier {
       let codeMeasurements;
       let releaseTag: string;
       try {
-        const verifiedCode = await verifySigstoreBundle(sigstoreBundle, digest, this.configRepo);
+        const verifiedCode = await verifySigstoreBundle(
+          sigstoreBundle,
+          digest,
+          this.configRepo,
+          selectedReleaseTag
+        );
         codeMeasurements = verifiedCode.measurement;
         releaseTag = verifiedCode.releaseTag;
         steps.verifyCode = { status: 'success' };
@@ -117,7 +121,7 @@ export class Verifier {
         enclaveFingerprint: await measurementFingerprint(amdVerification.measurement),
         selectedRouterEndpoint: domain,
         securityVerified: true,
-        verifier: VERIFIER_IDENTITY,
+        verifier: verifierIdentity(),
         verifiedAt: new Date().toISOString(),
         steps
       };
@@ -145,7 +149,7 @@ export class Verifier {
       enclaveFingerprint: '',
       selectedRouterEndpoint: domain,
       securityVerified: false,
-      verifier: VERIFIER_IDENTITY,
+      verifier: verifierIdentity(),
       steps
     };
   }

--- a/packages/verifier/src/index.ts
+++ b/packages/verifier/src/index.ts
@@ -10,6 +10,7 @@ export {
 export { verifyAttestation } from './attestation.js';
 export { assembleAttestationBundle } from './bundle.js';
 export { Verifier } from './client.js';
+export { cloneJsonSnapshot } from './json.js';
 export { VERIFICATION_DOCUMENT_SCHEMA_VERSION, VERIFIER_NAME, VERIFIER_VERSION } from './version.js';
 export { PredicateType, compareMeasurements, measurementFingerprint, hashAttestationDocument } from './types.js';
 export type { AttestationDocument, AttestationMeasurement, AttestationResponse, AttestationBundle, VerificationDocument, VerificationStepState, HardwareMeasurement, SoftwareIdentity } from './types.js';

--- a/packages/verifier/src/index.ts
+++ b/packages/verifier/src/index.ts
@@ -10,7 +10,7 @@ export {
 export { verifyAttestation } from './attestation.js';
 export { assembleAttestationBundle } from './bundle.js';
 export { Verifier } from './client.js';
-export { VERIFIER_NAME, VERIFIER_VERSION } from './version.js';
+export { VERIFICATION_DOCUMENT_SCHEMA_VERSION, VERIFIER_NAME, VERIFIER_VERSION } from './version.js';
 export { PredicateType, compareMeasurements, measurementFingerprint, hashAttestationDocument } from './types.js';
 export type { AttestationDocument, AttestationMeasurement, AttestationResponse, AttestationBundle, VerificationDocument, VerificationStepState, HardwareMeasurement, SoftwareIdentity } from './types.js';
 export type { VerifierOptions } from './client.js';

--- a/packages/verifier/src/index.ts
+++ b/packages/verifier/src/index.ts
@@ -10,7 +10,7 @@ export {
 export { verifyAttestation } from './attestation.js';
 export { assembleAttestationBundle } from './bundle.js';
 export { Verifier } from './client.js';
-export { cloneJsonSnapshot } from './json.js';
+export { cloneVerificationDocument } from './json.js';
 export { VERIFICATION_DOCUMENT_SCHEMA_VERSION, VERIFIER_NAME, VERIFIER_VERSION } from './version.js';
 export { PredicateType, compareMeasurements, measurementFingerprint, hashAttestationDocument } from './types.js';
 export type { AttestationDocument, AttestationMeasurement, AttestationResponse, AttestationBundle, VerificationDocument, VerificationStepState, HardwareMeasurement, SoftwareIdentity } from './types.js';

--- a/packages/verifier/src/index.ts
+++ b/packages/verifier/src/index.ts
@@ -10,7 +10,8 @@ export {
 export { verifyAttestation } from './attestation.js';
 export { assembleAttestationBundle } from './bundle.js';
 export { Verifier } from './client.js';
+export { VERIFIER_NAME, VERIFIER_VERSION } from './version.js';
 export { PredicateType, compareMeasurements, measurementFingerprint, hashAttestationDocument } from './types.js';
-export type { AttestationDocument, AttestationMeasurement, AttestationResponse, AttestationBundle, VerificationDocument, VerificationStepState, HardwareMeasurement } from './types.js';
+export type { AttestationDocument, AttestationMeasurement, AttestationResponse, AttestationBundle, VerificationDocument, VerificationStepState, HardwareMeasurement, SoftwareIdentity } from './types.js';
 export type { VerifierOptions } from './client.js';
 export { verifyCertificate, type CertVerificationResult } from './cert-verify.js';

--- a/packages/verifier/src/json.ts
+++ b/packages/verifier/src/json.ts
@@ -1,3 +1,5 @@
-export function cloneJsonSnapshot<T>(value: T): T {
-  return JSON.parse(JSON.stringify(value)) as T;
+import type { VerificationDocument } from './types.js';
+
+export function cloneVerificationDocument(document: VerificationDocument): VerificationDocument {
+  return structuredClone(document);
 }

--- a/packages/verifier/src/json.ts
+++ b/packages/verifier/src/json.ts
@@ -1,0 +1,3 @@
+export function cloneJsonSnapshot<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T;
+}

--- a/packages/verifier/src/sigstore.ts
+++ b/packages/verifier/src/sigstore.ts
@@ -6,6 +6,7 @@ import { AttestationError, wrapOrThrow } from './errors.js';
 
 class GitHubWorkflowRefPattern implements VerificationPolicy {
   private pattern: RegExp;
+  private verifiedWorkflowRef?: string;
 
   constructor(pattern: string | RegExp) {
     this.pattern = typeof pattern === 'string' ? new RegExp(pattern) : pattern;
@@ -21,7 +22,20 @@ class GitHubWorkflowRefPattern implements VerificationPolicy {
         `Sigstore certificate verification failed: Workflow reference "${ext.workflowRef}" does not match expected pattern (must be a tagged release)`
       );
     }
+    this.verifiedWorkflowRef = ext.workflowRef;
   }
+
+  releaseTag(): string {
+    if (!this.verifiedWorkflowRef) {
+      throw new AttestationError('Sigstore certificate verification failed: GitHub workflow reference was not verified');
+    }
+    return this.verifiedWorkflowRef.slice('refs/tags/'.length);
+  }
+}
+
+export interface VerifiedCodeMeasurement {
+  measurement: AttestationMeasurement;
+  releaseTag: string;
 }
 
 /**
@@ -39,7 +53,7 @@ export async function verifySigstoreBundle(
   bundleJson: unknown,
   digest: string,
   repo: string
-): Promise<AttestationMeasurement> {
+): Promise<VerifiedCodeMeasurement> {
 
   try {
     const {
@@ -68,10 +82,11 @@ export async function verifySigstoreBundle(
     }
 
     // Create policy for GitHub Actions certificate identity
+    const workflowRefPolicy = new GitHubWorkflowRefPattern(/^refs\/tags\//);
     const policy = new AllOf([
       new OIDCIssuer(GITHUB_OIDC_ISSUER),
       new GitHubWorkflowRepository(repo),
-      new GitHubWorkflowRefPattern(/^refs\/tags\//),
+      workflowRefPolicy,
     ]);
 
     // Verify the DSSE envelope and get the payload
@@ -128,8 +143,11 @@ export async function verifySigstoreBundle(
     }
 
     return {
-      type: predicateType,
-      registers,
+      measurement: {
+        type: predicateType,
+        registers,
+      },
+      releaseTag: workflowRefPolicy.releaseTag(),
     };
 
   } catch (e) {

--- a/packages/verifier/src/sigstore.ts
+++ b/packages/verifier/src/sigstore.ts
@@ -144,7 +144,7 @@ export async function verifySigstoreBundle(
     }
 
     const releaseTag = workflowRefPolicy.releaseTag();
-    if (expectedReleaseTag && expectedReleaseTag !== releaseTag) {
+    if (expectedReleaseTag !== undefined && expectedReleaseTag !== releaseTag) {
       throw new AttestationError(
         `Release tag mismatch: selected release "${expectedReleaseTag}" was signed from "${releaseTag}"`
       );

--- a/packages/verifier/src/sigstore.ts
+++ b/packages/verifier/src/sigstore.ts
@@ -52,7 +52,8 @@ export interface VerifiedCodeMeasurement {
 export async function verifySigstoreBundle(
   bundleJson: unknown,
   digest: string,
-  repo: string
+  repo: string,
+  expectedReleaseTag?: string
 ): Promise<VerifiedCodeMeasurement> {
 
   try {
@@ -142,12 +143,19 @@ export async function verifySigstoreBundle(
       throw new AttestationError(`Unsupported in-toto predicate type: "${predicateType}". Only SNP/TDX multiplatform V1 is supported`);
     }
 
+    const releaseTag = workflowRefPolicy.releaseTag();
+    if (expectedReleaseTag && expectedReleaseTag !== releaseTag) {
+      throw new AttestationError(
+        `Release tag mismatch: selected release "${expectedReleaseTag}" was signed from "${releaseTag}"`
+      );
+    }
+
     return {
       measurement: {
         type: predicateType,
         registers,
       },
-      releaseTag: workflowRefPolicy.releaseTag(),
+      releaseTag,
     };
 
   } catch (e) {

--- a/packages/verifier/src/types.ts
+++ b/packages/verifier/src/types.ts
@@ -19,6 +19,8 @@ export interface AttestationBundle {
   enclaveAttestationReport: AttestationDocument;
   /** SHA256 digest of the release */
   digest: string;
+  /** Release tag selected for the digest, verified against Sigstore when present */
+  releaseTag?: string;
   /** Sigstore bundle for code provenance verification */
   sigstoreBundle: unknown;
   /** Base64-encoded VCEK certificate (DER format) */

--- a/packages/verifier/src/types.ts
+++ b/packages/verifier/src/types.ts
@@ -19,8 +19,6 @@ export interface AttestationBundle {
   enclaveAttestationReport: AttestationDocument;
   /** SHA256 digest of the release */
   digest: string;
-  /** Release tag containing the digest, when known */
-  releaseTag?: string;
   /** Sigstore bundle for code provenance verification */
   sigstoreBundle: unknown;
   /** Base64-encoded VCEK certificate (DER format) */

--- a/packages/verifier/src/types.ts
+++ b/packages/verifier/src/types.ts
@@ -19,6 +19,8 @@ export interface AttestationBundle {
   enclaveAttestationReport: AttestationDocument;
   /** SHA256 digest of the release */
   digest: string;
+  /** Release tag containing the digest, when known */
+  releaseTag?: string;
   /** Sigstore bundle for code provenance verification */
   sigstoreBundle: unknown;
   /** Base64-encoded VCEK certificate (DER format) */
@@ -115,7 +117,7 @@ export async function hashAttestationDocument(doc: AttestationDocument): Promise
 }
 
 export interface VerificationStepState {
-  status: 'pending' | 'success' | 'failed';
+  status: 'pending' | 'success' | 'failed' | 'skipped';
   error?: string;
 }
 
@@ -125,9 +127,16 @@ export interface HardwareMeasurement {
   RTMR0?: string;
 }
 
+export interface SoftwareIdentity {
+  name: string;
+  version: string;
+}
+
 export interface VerificationDocument {
+  schemaVersion?: 1;
   configRepo: string;
   enclaveHost: string;
+  releaseTag?: string;
   releaseDigest: string;
   codeMeasurement: AttestationMeasurement;
   enclaveMeasurement: AttestationResponse;
@@ -138,6 +147,8 @@ export interface VerificationDocument {
   enclaveFingerprint: string;
   selectedRouterEndpoint: string;
   securityVerified: boolean;
+  verifier?: SoftwareIdentity;
+  verifiedAt?: string;
   steps: {
     fetchDigest: VerificationStepState;
     verifyCode: VerificationStepState;
@@ -147,4 +158,3 @@ export interface VerificationDocument {
     otherError?: VerificationStepState;
   };
 }
-

--- a/packages/verifier/src/version.ts
+++ b/packages/verifier/src/version.ts
@@ -1,2 +1,3 @@
 export const VERIFIER_NAME = '@tinfoilsh/verifier';
 export const VERIFIER_VERSION = '1.2.0';
+export const VERIFICATION_DOCUMENT_SCHEMA_VERSION = 1 as const;

--- a/packages/verifier/src/version.ts
+++ b/packages/verifier/src/version.ts
@@ -1,0 +1,2 @@
+export const VERIFIER_NAME = '@tinfoilsh/verifier';
+export const VERIFIER_VERSION = '1.2.0';

--- a/packages/verifier/test/bundle.test.ts
+++ b/packages/verifier/test/bundle.test.ts
@@ -54,6 +54,30 @@ describe('Bundle Verification', () => {
     expect(doc!.steps.verifyCertificate?.status).toBe('success');
   });
 
+  it('should reject a selected release tag that differs from signed provenance', async () => {
+    const verifier = new Verifier({
+      serverURL: `https://${bundle.domain}`,
+      configRepo: 'tinfoilsh/confidential-model-router',
+    });
+
+    await expect(
+      verifier.verifyBundle({ ...bundle, releaseTag: 'forged-release' })
+    ).rejects.toThrow('Release tag mismatch');
+  });
+
+  it('should not share mutable verifier identity between documents', async () => {
+    const verifier = new Verifier({
+      serverURL: `https://${bundle.domain}`,
+      configRepo: 'tinfoilsh/confidential-model-router',
+    });
+
+    await verifier.verifyBundle(bundle);
+    verifier.getVerificationDocument()!.verifier!.name = 'modified';
+    await verifier.verifyBundle(bundle);
+
+    expect(verifier.getVerificationDocument()!.verifier!.name).toBe('@tinfoilsh/verifier');
+  });
+
   it('should verify certificate containing HPKE key and attestation hash', async () => {
     const verifier = new Verifier({
       serverURL: `https://${bundle.domain}`,

--- a/packages/verifier/test/bundle.test.ts
+++ b/packages/verifier/test/bundle.test.ts
@@ -65,17 +65,34 @@ describe('Bundle Verification', () => {
     ).rejects.toThrow('Release tag mismatch');
   });
 
-  it('should not share mutable verifier identity between documents', async () => {
+  it('should reject an empty selected release tag', async () => {
+    const verifier = new Verifier({
+      serverURL: `https://${bundle.domain}`,
+      configRepo: 'tinfoilsh/confidential-model-router',
+    });
+
+    await expect(
+      verifier.verifyBundle({ ...bundle, releaseTag: '' })
+    ).rejects.toThrow('Release tag mismatch');
+  });
+
+  it('should return deeply cloned verification document snapshots', async () => {
     const verifier = new Verifier({
       serverURL: `https://${bundle.domain}`,
       configRepo: 'tinfoilsh/confidential-model-router',
     });
 
     await verifier.verifyBundle(bundle);
-    verifier.getVerificationDocument()!.verifier!.name = 'modified';
-    await verifier.verifyBundle(bundle);
+    const original = verifier.getVerificationDocument()!;
+    const snapshot = verifier.getVerificationDocument()!;
+    snapshot.securityVerified = false;
+    snapshot.releaseTag = 'modified';
+    snapshot.verifier!.name = 'modified';
+    snapshot.steps.verifyCode.status = 'failed';
+    snapshot.codeMeasurement.registers[0] = 'modified';
+    snapshot.enclaveMeasurement.measurement.registers[0] = 'modified';
 
-    expect(verifier.getVerificationDocument()!.verifier!.name).toBe('@tinfoilsh/verifier');
+    expect(verifier.getVerificationDocument()).toEqual(original);
   });
 
   it('should verify certificate containing HPKE key and attestation hash', async () => {

--- a/packages/verifier/test/bundle.test.ts
+++ b/packages/verifier/test/bundle.test.ts
@@ -34,14 +34,14 @@ describe('Bundle Verification', () => {
     });
 
     const startedAt = Date.now();
-    await verifier.verifyBundle({ ...bundle, releaseTag: 'v1.2.3' });
+    await verifier.verifyBundle(bundle);
     const doc = verifier.getVerificationDocument();
 
     expect(doc).toBeDefined();
     expect(doc!.securityVerified).toBe(true);
     expect(doc!.enclaveHost).toBe(bundle.domain);
     expect(doc!.schemaVersion).toBe(1);
-    expect(doc!.releaseTag).toBeUndefined();
+    expect(doc!.releaseTag).toBeTruthy();
     expect(doc!.releaseDigest).toBe(bundle.digest);
     expect(doc!.verifier?.name).toBe('@tinfoilsh/verifier');
     expect(doc!.verifier?.version).toBeTruthy();

--- a/packages/verifier/test/bundle.test.ts
+++ b/packages/verifier/test/bundle.test.ts
@@ -83,7 +83,7 @@ describe('Bundle Verification', () => {
     });
 
     await verifier.verifyBundle(bundle);
-    const original = verifier.getVerificationDocument()!;
+    const expected = structuredClone(verifier.getVerificationDocument()!);
     const snapshot = verifier.getVerificationDocument()!;
     snapshot.securityVerified = false;
     snapshot.releaseTag = 'modified';
@@ -92,7 +92,7 @@ describe('Bundle Verification', () => {
     snapshot.codeMeasurement.registers[0] = 'modified';
     snapshot.enclaveMeasurement.measurement.registers[0] = 'modified';
 
-    expect(verifier.getVerificationDocument()).toEqual(original);
+    expect(verifier.getVerificationDocument()).toEqual(expected);
   });
 
   it('should verify certificate containing HPKE key and attestation hash', async () => {

--- a/packages/verifier/test/bundle.test.ts
+++ b/packages/verifier/test/bundle.test.ts
@@ -33,13 +33,20 @@ describe('Bundle Verification', () => {
       configRepo: 'tinfoilsh/confidential-model-router',
     });
 
-    await verifier.verifyBundle(bundle);
+    const startedAt = Date.now();
+    await verifier.verifyBundle({ ...bundle, releaseTag: 'v1.2.3' });
     const doc = verifier.getVerificationDocument();
 
     expect(doc).toBeDefined();
     expect(doc!.securityVerified).toBe(true);
     expect(doc!.enclaveHost).toBe(bundle.domain);
+    expect(doc!.schemaVersion).toBe(1);
+    expect(doc!.releaseTag).toBeUndefined();
     expect(doc!.releaseDigest).toBe(bundle.digest);
+    expect(doc!.verifier?.name).toBe('@tinfoilsh/verifier');
+    expect(doc!.verifier?.version).toBeTruthy();
+    expect(Date.parse(doc!.verifiedAt!)).toBeGreaterThanOrEqual(startedAt);
+    expect(Date.parse(doc!.verifiedAt!)).toBeLessThanOrEqual(Date.now());
     expect(doc!.steps.fetchDigest.status).toBe('success');
     expect(doc!.steps.verifyCode.status).toBe('success');
     expect(doc!.steps.verifyEnclave.status).toBe('success');
@@ -78,6 +85,7 @@ describe('Bundle Verification', () => {
     });
 
     await expect(verifier.verifyBundle(tamperedBundle)).rejects.toThrow();
+    expect(verifier.getVerificationDocument()?.verifiedAt).toBeUndefined();
   });
 
   it('should return TLS and HPKE public keys from bundle verification', async () => {

--- a/packages/verifier/test/version.test.ts
+++ b/packages/verifier/test/version.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from 'vitest';
+import packageMetadata from '../package.json';
+import { VERIFIER_NAME, VERIFIER_VERSION } from '../src/version.js';
+
+describe('verifier identity', () => {
+  it('matches package metadata', () => {
+    expect(VERIFIER_NAME).toBe(packageMetadata.name);
+    expect(VERIFIER_VERSION).toBe(packageMetadata.version);
+  });
+});


### PR DESCRIPTION
## Summary
- add release identity, verifier identity, and successful verification time to verification documents
- preserve standalone verification so callers can pin their own Node transport
- bump both JavaScript packages to 1.2.0 and validate version identity during releases

## Testing
- `npm test`
- `npm run build`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose provenance in verification documents so consumers can see who verified, when, and from which tagged release, and return deep‑cloned, type‑safe document snapshots to prevent external mutation. Also bind selected release tags to signed provenance and surface the tag across ATC and verification.

- **New Features**
  - `VerificationDocument`: add `schemaVersion: 1`, `verifier` {name, version}, `verifiedAt`, and optional `releaseTag`; step state supports `skipped`.
  - `verifySigstoreBundle()` enforces tagged GitHub Actions refs, returns `{ measurement, releaseTag }`, validates an optional selected tag; `verify()`/`verifyBundle()` save it; `assembleAttestationBundle()` and `fetchAttestationBundle()` include `releaseTag`.
  - `getVerificationDocument()` now returns deep‑cloned snapshots in `@tinfoilsh/verifier` and `tinfoil` via exported `cloneVerificationDocument`; export `VERIFIER_NAME`, `VERIFIER_VERSION`, `VERIFICATION_DOCUMENT_SCHEMA_VERSION`, and `SoftwareIdentity`; README documents using your own transport with SPKI pinning; `tinfoil` sets `schemaVersion` and verifier identity in pending docs.

- **Dependencies**
  - Bump `@tinfoilsh/verifier` and `tinfoil` to `1.2.0`; update internal references.
  - Release workflow runs `npm test` before build; `test:browser` builds `@tinfoilsh/verifier` before running browser tests.

<sup>Written for commit 63f5037616cc8a407aa6194e9a81b4ac918ee7a8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-js/pull/192?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

