### PR TITLE
Build verifier before release tests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,11 +30,11 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Test
-        run: npm test
-
       - name: Build
         run: npm run build
+
+      - name: Test
+        run: npm test
 
       - name: Publish @tinfoilsh/verifier to npm
         run: npm publish --access public --provenance

--- a/package-lock.json
+++ b/package-lock.json
@@ -3865,12 +3865,12 @@
       }
     },
     "packages/tinfoil": {
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/openai-compatible": "^3.0.7",
         "@freedomofpress/sigstore-browser": "^0.1.14",
-        "@tinfoilsh/verifier": "1.2.0",
+        "@tinfoilsh/verifier": "1.2.1",
         "@types/ws": "^8.18.1",
         "ehbp": "^0.3.2",
         "openai": "^6.46.0",
@@ -3929,7 +3929,7 @@
     },
     "packages/verifier": {
       "name": "@tinfoilsh/verifier",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@freedomofpress/crypto-browser": "^0.1.7",

--- a/packages/tinfoil/package.json
+++ b/packages/tinfoil/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tinfoil",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Tinfoil secure OpenAI client wrapper",
   "type": "module",
   "main": "dist/index.js",
@@ -63,7 +63,7 @@
   "dependencies": {
     "@ai-sdk/openai-compatible": "^3.0.7",
     "@freedomofpress/sigstore-browser": "^0.1.14",
-    "@tinfoilsh/verifier": "1.2.0",
+    "@tinfoilsh/verifier": "1.2.1",
     "@types/ws": "^8.18.1",
     "ehbp": "^0.3.2",
     "openai": "^6.46.0",

--- a/packages/verifier/package.json
+++ b/packages/verifier/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tinfoilsh/verifier",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "AMD SEV-SNP attestation verifier for Node.js and browsers",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/verifier/src/version.ts
+++ b/packages/verifier/src/version.ts
@@ -1,3 +1,3 @@
 export const VERIFIER_NAME = '@tinfoilsh/verifier';
-export const VERIFIER_VERSION = '1.2.0';
+export const VERIFIER_VERSION = '1.2.1';
 export const VERIFICATION_DOCUMENT_SCHEMA_VERSION = 1 as const;


### PR DESCRIPTION
## Summary
- build the local verifier workspace before running release tests
- bump both JavaScript packages to 1.2.1 after the unpublished v1.2.0 release failed
- keep the verifier runtime identity synchronized with package metadata

## Testing
- clean `npm ci`
- `npm run build`
- `npm test`

After merge, create tag `v1.2.1`; do not rewrite `v1.2.0`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Build the `@tinfoilsh/verifier` package before running release tests to ensure tests use built code. Bumps `@tinfoilsh/verifier` and `tinfoil` to 1.2.1 and syncs the runtime version with package metadata.

- **Bug Fixes**
  - Reorder release workflow: build before test.
  - Update runtime `VERIFIER_VERSION` and align package versions and `tinfoil`’s dependency on `@tinfoilsh/verifier` to 1.2.1.

- **Migration**
  - After merge, create and push tag `v1.2.1`; do not rewrite `v1.2.0`.

<sup>Written for commit b60774e075daafd845acad645add402eb363cc24. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-js/pull/193?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

