### PR TITLE
Bind the legacy inference base to its enclave

### DIFF
--- a/packages/tinfoil/src/config.ts
+++ b/packages/tinfoil/src/config.ts
@@ -8,6 +8,12 @@ export const TINFOIL_CONFIG = {
   ATC_BASE_URL: "https://atc.tinfoil.sh",
 
   /**
+   * Stable legacy inference enclave origin. This endpoint does not forward
+   * requests to an independently selected router.
+   */
+  INFERENCE_ORIGIN: "https://inference.tinfoil.sh",
+
+  /**
    * The GitHub repository for the router code attestation
    */
   DEFAULT_ROUTER_REPO: "tinfoilsh/confidential-model-router",

--- a/packages/tinfoil/src/secure-client.ts
+++ b/packages/tinfoil/src/secure-client.ts
@@ -209,7 +209,7 @@ export class SecureClient {
       baseOrigin = baseURL.origin;
     }
 
-    const configuredEnclaveURL = options.enclaveURL?.trim();
+    let configuredEnclaveURL = options.enclaveURL?.trim();
     let enclaveOrigin: string | undefined;
     if (options.enclaveURL !== undefined) {
       const enclaveURL = parseConfiguredURL(
@@ -219,6 +219,7 @@ export class SecureClient {
       );
       if (isInferenceHost(enclaveURL) && enclaveURL.port === "") {
         enclaveURL.hostname = INFERENCE_HOST;
+        configuredEnclaveURL = TINFOIL_CONFIG.INFERENCE_ORIGIN;
       }
       enclaveOrigin = enclaveURL.origin;
     }

--- a/packages/tinfoil/src/secure-client.ts
+++ b/packages/tinfoil/src/secure-client.ts
@@ -161,6 +161,7 @@ export class SecureClient {
   private attestedTlsPublicKeyFingerprint?: string;
 
   constructor(options: SecureClientOptions = {}) {
+    let baseOrigin: string | undefined;
     // Validate provided URLs, including the empty string: URL resolution
     // keeps "" (via ??) rather than falling back, so an unguarded empty value
     // would surface later as a confusing "Invalid URL" instead of a clear error.
@@ -176,14 +177,41 @@ export class SecureClient {
       if (baseURL.protocol !== "http:" && baseURL.protocol !== "https:") {
         throw new ConfigurationError(`baseURL must be a valid HTTP(S) URL. Got: ${options.baseURL}`);
       }
+      baseOrigin = baseURL.origin;
     }
-    if (options.enclaveURL !== undefined && !options.enclaveURL.startsWith("https://")) {
-      throw new ConfigurationError(`enclaveURL must use HTTPS. Got: ${options.enclaveURL}`);
+
+    let enclaveOrigin: string | undefined;
+    if (options.enclaveURL !== undefined) {
+      let enclaveURL: URL;
+      try {
+        enclaveURL = new URL(options.enclaveURL);
+      } catch {
+        throw new ConfigurationError(`enclaveURL must use HTTPS. Got: ${options.enclaveURL}`);
+      }
+      if (enclaveURL.protocol !== "https:") {
+        throw new ConfigurationError(`enclaveURL must use HTTPS. Got: ${options.enclaveURL}`);
+      }
+      enclaveOrigin = enclaveURL.origin;
     }
     if (options.attestationBundleURL !== undefined && !options.attestationBundleURL.startsWith("https://")) {
       throw new ConfigurationError(`attestationBundleURL must use HTTPS. Got: ${options.attestationBundleURL}`);
     }
-    if (options.configRepo && !options.enclaveURL) {
+
+    let resolvedEnclaveURL = options.enclaveURL;
+    if (baseOrigin === TINFOIL_CONFIG.INFERENCE_ORIGIN) {
+      if (enclaveOrigin && enclaveOrigin !== TINFOIL_CONFIG.INFERENCE_ORIGIN) {
+        throw new ConfigurationError(
+          `baseURL ${options.baseURL} cannot route to enclaveURL ${options.enclaveURL}; ` +
+          "use a proxy that forwards X-Tinfoil-Enclave-Url or connect directly",
+        );
+      }
+      // inference.tinfoil.sh is a stable enclave identity, not a
+      // router-forwarding proxy. Request its matching bundle rather than pairing
+      // this base URL with a randomly selected default-router HPKE key.
+      resolvedEnclaveURL = TINFOIL_CONFIG.INFERENCE_ORIGIN;
+    }
+
+    if (options.configRepo && !resolvedEnclaveURL) {
       throw new ConfigurationError("configRepo requires enclaveURL — without it, ATC always uses the default router repo.");
     } else if (options.enclaveURL && !options.configRepo) {
       console.warn(`[tinfoil] No configRepo specified, verifying against "${TINFOIL_CONFIG.DEFAULT_ROUTER_REPO}".`);
@@ -191,7 +219,7 @@ export class SecureClient {
 
     this.config = {
       baseURL: options.baseURL,
-      enclaveURL: options.enclaveURL,
+      enclaveURL: resolvedEnclaveURL,
       configRepo: options.configRepo ?? TINFOIL_CONFIG.DEFAULT_ROUTER_REPO,
       transport: options.transport || 'ehbp',
       attestationBundleURL: options.attestationBundleURL,

--- a/packages/tinfoil/src/secure-client.ts
+++ b/packages/tinfoil/src/secure-client.ts
@@ -104,6 +104,29 @@ function createPendingVerificationDocument(configRepo: string): VerificationDocu
   };
 }
 
+function parseConfiguredURL(
+  value: string,
+  allowedProtocols: readonly string[],
+  errorMessage: string,
+): URL {
+  let parsed: URL;
+  try {
+    parsed = new URL(value.trim());
+  } catch (cause) {
+    throw new ConfigurationError(errorMessage, { cause: cause as Error });
+  }
+  if (!allowedProtocols.includes(parsed.protocol)) {
+    throw new ConfigurationError(errorMessage);
+  }
+  return parsed;
+}
+
+const INFERENCE_HOST = new URL(TINFOIL_CONFIG.INFERENCE_ORIGIN).hostname;
+
+function isInferenceHost(url: URL): boolean {
+  return url.hostname.toLowerCase().replace(/\.$/, "") === INFERENCE_HOST;
+}
+
 /**
  * Low-level secure client providing a verified fetch function for custom HTTP requests.
  * 
@@ -161,43 +184,55 @@ export class SecureClient {
   private attestedTlsPublicKeyFingerprint?: string;
 
   constructor(options: SecureClientOptions = {}) {
+    let configuredBaseURL = options.baseURL?.trim();
     let baseOrigin: string | undefined;
     // Validate provided URLs, including the empty string: URL resolution
     // keeps "" (via ??) rather than falling back, so an unguarded empty value
     // would surface later as a confusing "Invalid URL" instead of a clear error.
     if (options.baseURL !== undefined) {
-      let baseURL: URL;
-      try {
-        baseURL = new URL(options.baseURL);
-      } catch (cause) {
-        throw new ConfigurationError(`baseURL must be a valid HTTP(S) URL. Got: ${options.baseURL}`, {
-          cause: cause as Error,
-        });
-      }
-      if (baseURL.protocol !== "http:" && baseURL.protocol !== "https:") {
-        throw new ConfigurationError(`baseURL must be a valid HTTP(S) URL. Got: ${options.baseURL}`);
+      const baseURL = parseConfiguredURL(
+        options.baseURL,
+        ["http:", "https:"],
+        `baseURL must be a valid HTTP(S) URL. Got: ${options.baseURL}`,
+      );
+      if (isInferenceHost(baseURL)) {
+        if (baseURL.protocol !== "https:" || baseURL.port !== "") {
+          throw new ConfigurationError(
+            `baseURL for ${INFERENCE_HOST} must use its standard HTTPS endpoint. Got: ${options.baseURL}`,
+          );
+        }
+        // Treat the DNS root-dot spelling as the same host, then keep one
+        // canonical routing identity throughout attestation and requests.
+        baseURL.hostname = INFERENCE_HOST;
+        configuredBaseURL = baseURL.toString();
       }
       baseOrigin = baseURL.origin;
     }
 
+    const configuredEnclaveURL = options.enclaveURL?.trim();
     let enclaveOrigin: string | undefined;
     if (options.enclaveURL !== undefined) {
-      let enclaveURL: URL;
-      try {
-        enclaveURL = new URL(options.enclaveURL);
-      } catch {
-        throw new ConfigurationError(`enclaveURL must use HTTPS. Got: ${options.enclaveURL}`);
-      }
-      if (enclaveURL.protocol !== "https:") {
-        throw new ConfigurationError(`enclaveURL must use HTTPS. Got: ${options.enclaveURL}`);
+      const enclaveURL = parseConfiguredURL(
+        options.enclaveURL,
+        ["https:"],
+        `enclaveURL must use HTTPS. Got: ${options.enclaveURL}`,
+      );
+      if (isInferenceHost(enclaveURL) && enclaveURL.port === "") {
+        enclaveURL.hostname = INFERENCE_HOST;
       }
       enclaveOrigin = enclaveURL.origin;
     }
-    if (options.attestationBundleURL !== undefined && !options.attestationBundleURL.startsWith("https://")) {
-      throw new ConfigurationError(`attestationBundleURL must use HTTPS. Got: ${options.attestationBundleURL}`);
+
+    const configuredAttestationBundleURL = options.attestationBundleURL?.trim();
+    if (options.attestationBundleURL !== undefined) {
+      parseConfiguredURL(
+        options.attestationBundleURL,
+        ["https:"],
+        `attestationBundleURL must use HTTPS. Got: ${options.attestationBundleURL}`,
+      );
     }
 
-    let resolvedEnclaveURL = options.enclaveURL;
+    let resolvedEnclaveURL = configuredEnclaveURL;
     if (baseOrigin === TINFOIL_CONFIG.INFERENCE_ORIGIN) {
       if (enclaveOrigin && enclaveOrigin !== TINFOIL_CONFIG.INFERENCE_ORIGIN) {
         throw new ConfigurationError(
@@ -218,11 +253,11 @@ export class SecureClient {
     }
 
     this.config = {
-      baseURL: options.baseURL,
+      baseURL: configuredBaseURL,
       enclaveURL: resolvedEnclaveURL,
       configRepo: options.configRepo ?? TINFOIL_CONFIG.DEFAULT_ROUTER_REPO,
       transport: options.transport || 'ehbp',
-      attestationBundleURL: options.attestationBundleURL,
+      attestationBundleURL: configuredAttestationBundleURL,
       userCacheSecret: options.userCacheSecret,
     };
     this.verificationDocument = createPendingVerificationDocument(this.config.configRepo);

--- a/packages/tinfoil/test/client.inference-tinfoil.browser.integration.test.ts
+++ b/packages/tinfoil/test/client.inference-tinfoil.browser.integration.test.ts
@@ -36,7 +36,10 @@ describe("TinfoilAI - enclaveURL integration", () => {
     expect(verificationDoc).toBeTruthy();
     expect(verificationDoc.configRepo).toBe(TINFOIL_CONFIG.DEFAULT_ROUTER_REPO);
     expect(verificationDoc.securityVerified).toBe(true);
-    expect(verificationDoc.enclaveHost).toBeTruthy();
+    expect(verificationDoc.enclaveHost).toBe("inference.tinfoil.sh");
+
+    const response = await client.models.list();
+    expect(response.data.length).toBeGreaterThan(0);
   }, 60000);
 });
 
@@ -71,7 +74,12 @@ describe("SecureClient - enclaveURL integration", () => {
     expect(verificationDoc).toBeTruthy();
     expect(verificationDoc.configRepo).toBe(TINFOIL_CONFIG.DEFAULT_ROUTER_REPO);
     expect(verificationDoc.securityVerified).toBe(true);
-    expect(verificationDoc.enclaveHost).toBeTruthy();
+    expect(verificationDoc.enclaveHost).toBe("inference.tinfoil.sh");
+
+    const response = await client.fetch("/v1/models", {
+      method: "GET",
+    });
+    expect(response.status).toBe(200);
   }, 60000);
 
   it("should make successful fetch request when enclaveURL is set to inference.tinfoil.sh", async () => {

--- a/packages/tinfoil/test/secure-client.test.ts
+++ b/packages/tinfoil/test/secure-client.test.ts
@@ -485,6 +485,24 @@ describe("SecureClient", () => {
       })).not.toThrow();
     });
 
+    it("should persist the canonical identity for a standalone root-dot enclave URL", async () => {
+      const { SecureClient } = await import("../src/secure-client");
+      const { fetchAttestationBundle } = await import("../src/atc.js");
+
+      const client = new SecureClient({
+        enclaveURL: "https://inference.tinfoil.sh.",
+      });
+      await client.ready();
+
+      expect(client.getEnclaveURL()).toBe("https://inference.tinfoil.sh");
+      expect(client.getEnclaveBaseURL()).toBe("https://inference.tinfoil.sh/v1/");
+      expect(fetchAttestationBundle).toHaveBeenCalledWith({
+        atcBaseUrl: undefined,
+        enclaveURL: "https://inference.tinfoil.sh",
+        configRepo: undefined,
+      });
+    });
+
     it("should canonicalize the root-dot spelling of the official inference baseURL", async () => {
       const { SecureClient } = await import("../src/secure-client");
       const { fetchAttestationBundle } = await import("../src/atc.js");

--- a/packages/tinfoil/test/secure-client.test.ts
+++ b/packages/tinfoil/test/secure-client.test.ts
@@ -443,6 +443,39 @@ describe("SecureClient", () => {
   });
 
   describe("constructor validation", () => {
+    it("should bind the official inference baseURL to its matching enclave", async () => {
+      const { SecureClient } = await import("../src/secure-client");
+      const { fetchAttestationBundle } = await import("../src/atc.js");
+
+      const client = new SecureClient({
+        baseURL: "https://inference.tinfoil.sh/v1/",
+      });
+      await client.ready();
+
+      expect(client.getEnclaveURL()).toBe("https://inference.tinfoil.sh");
+      expect(fetchAttestationBundle).toHaveBeenCalledWith({
+        atcBaseUrl: undefined,
+        enclaveURL: "https://inference.tinfoil.sh",
+        configRepo: undefined,
+      });
+      expect(createSecureFetchMock).toHaveBeenCalledWith(
+        "https://inference.tinfoil.sh/v1/",
+        "mock-hpke-public-key",
+        undefined,
+        "https://inference.tinfoil.sh",
+        "test-secret",
+      );
+    });
+
+    it("should reject routing another enclave through the official inference baseURL", async () => {
+      const { SecureClient } = await import("../src/secure-client");
+
+      expect(() => new SecureClient({
+        baseURL: "https://inference.tinfoil.sh/v1/",
+        enclaveURL: "https://router.inf6.tinfoil.sh",
+      })).toThrow("cannot route to enclaveURL");
+    });
+
     it("should throw ConfigurationError when configRepo is set without enclaveURL", async () => {
       const { SecureClient } = await import("../src/secure-client");
 
@@ -627,6 +660,65 @@ describe("SecureClient", () => {
   });
 
   describe("KeyConfigMismatchError recovery", () => {
+    // Automatic clients must rotate the complete endpoint/key pair. Keeping the
+    // first bundle's domain would only fetch another key for the same failed
+    // route and would differ from reset() semantics.
+    it("should allow a fresh default bundle to select another router", async () => {
+      const { SecureClient } = await import("../src/secure-client");
+      const { fetchAttestationBundle } = await import("../src/atc.js");
+      const { KeyConfigMismatchError } = await import("ehbp");
+      vi.mocked(fetchAttestationBundle)
+        .mockResolvedValueOnce({
+          domain: "old-router.tinfoil.sh",
+          enclaveAttestationReport: { format: "test", body: "test" },
+          digest: "old-digest",
+          sigstoreBundle: {},
+          vcek: "test-vcek",
+        } as never)
+        .mockResolvedValueOnce({
+          domain: "new-router.tinfoil.sh",
+          enclaveAttestationReport: { format: "test", body: "test" },
+          digest: "new-digest",
+          sigstoreBundle: {},
+          vcek: "test-vcek",
+        } as never);
+      mockFetch
+        .mockRejectedValueOnce(new KeyConfigMismatchError("Key config mismatch"))
+        .mockResolvedValueOnce(new Response(JSON.stringify({ ok: true })));
+      const client = new SecureClient({ baseURL: "https://proxy.example.com/v1/" });
+
+      await client.ready();
+      await client.fetch("/test", { method: "GET" });
+
+      expect(fetchAttestationBundle).toHaveBeenNthCalledWith(1, {
+        atcBaseUrl: undefined,
+        enclaveURL: undefined,
+        configRepo: undefined,
+      });
+      expect(fetchAttestationBundle).toHaveBeenNthCalledWith(2, {
+        atcBaseUrl: undefined,
+        enclaveURL: undefined,
+        configRepo: undefined,
+      });
+      expect(createSecureFetchMock).toHaveBeenNthCalledWith(
+        1,
+        "https://proxy.example.com/v1/",
+        "mock-hpke-public-key",
+        undefined,
+        "https://old-router.tinfoil.sh",
+        "test-secret",
+      );
+      expect(createSecureFetchMock).toHaveBeenNthCalledWith(
+        2,
+        "https://proxy.example.com/v1/",
+        "mock-hpke-public-key",
+        undefined,
+        "https://new-router.tinfoil.sh",
+        "test-secret",
+      );
+      expect(client.getEnclaveURL()).toBe("https://new-router.tinfoil.sh");
+    });
+
     it("should re-attest and retry on KeyConfigMismatchError", async () => {
       const { SecureClient } = await import("../src/secure-client");
 

--- a/packages/tinfoil/test/secure-client.test.ts
+++ b/packages/tinfoil/test/secure-client.test.ts
@@ -476,6 +476,60 @@ describe("SecureClient", () => {
       })).toThrow("cannot route to enclaveURL");
     });
 
+    it("should accept a matching root-dot enclave identity for the official baseURL", async () => {
+      const { SecureClient } = await import("../src/secure-client");
+
+      expect(() => new SecureClient({
+        baseURL: "https://inference.tinfoil.sh/v1/",
+        enclaveURL: "https://inference.tinfoil.sh.",
+      })).not.toThrow();
+    });
+
+    it("should canonicalize the root-dot spelling of the official inference baseURL", async () => {
+      const { SecureClient } = await import("../src/secure-client");
+      const { fetchAttestationBundle } = await import("../src/atc.js");
+
+      const client = new SecureClient({
+        baseURL: "https://inference.tinfoil.sh./v1/",
+      });
+      await client.ready();
+
+      expect(client.getBaseURL()).toBe("https://inference.tinfoil.sh/v1/");
+      expect(client.getEnclaveURL()).toBe("https://inference.tinfoil.sh");
+      expect(fetchAttestationBundle).toHaveBeenCalledWith({
+        atcBaseUrl: undefined,
+        enclaveURL: "https://inference.tinfoil.sh",
+        configRepo: undefined,
+      });
+    });
+
+    it.each([
+      "http://inference.tinfoil.sh/v1/",
+      "https://inference.tinfoil.sh:8443/v1/",
+    ])("should reject a non-standard official inference endpoint %s", async (baseURL) => {
+      const { SecureClient } = await import("../src/secure-client");
+
+      expect(() => new SecureClient({ baseURL })).toThrow("must use its standard HTTPS endpoint");
+    });
+
+    it("should trim an explicitly configured enclave URL before using it", async () => {
+      const { SecureClient } = await import("../src/secure-client");
+      const { fetchAttestationBundle } = await import("../src/atc.js");
+
+      const client = new SecureClient({
+        enclaveURL: "  https://custom.example.com  ",
+        configRepo: "custom/repo",
+      });
+      await client.ready();
+
+      expect(client.getEnclaveURL()).toBe("https://custom.example.com");
+      expect(fetchAttestationBundle).toHaveBeenCalledWith({
+        atcBaseUrl: undefined,
+        enclaveURL: "https://custom.example.com",
+        configRepo: "custom/repo",
+      });
+    });
+
     it("should throw ConfigurationError when configRepo is set without enclaveURL", async () => {
       const { SecureClient } = await import("../src/secure-client");
 


### PR DESCRIPTION
## Summary

- treat https://inference.tinfoil.sh as a stable enclave identity rather than a forwarding proxy
- request its enclave-specific attestation bundle when used as the API base
- reject configurations that combine that base with another enclave
- preserve complete endpoint and key rotation for generic forwarding proxies
- extend browser integration coverage to perform a real inference request

## Security

The change prevents ciphertext sealed for one attested domain from being sent to another enclave. Generic proxy recovery continues to clear and rebuild the complete verified routing state.

## Validation

- npm run build
- npm run lint
- npm test: 173 tinfoil tests and 40 verifier tests passed
- built SDK returned 200 in a live Node request through the official inference base

The browser integration suite was not run locally because box3 has no Playwright Chromium; CI should exercise it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Binds https://inference.tinfoil.sh to its enclave and canonicalizes secure endpoint URLs. Previously this base could pair with a default-router key; now it always attests that enclave, persists its canonical identity (root-dot accepted), and rejects routing other enclaves through it.

- Adds `INFERENCE_ORIGIN`; when `baseURL` matches it (including root-dot), resolves and persists `enclaveURL` to the same origin and fetches its bundle.
- Canonicalizes and validates URLs: trims inputs; enforces HTTPS for `enclaveURL` and `attestationBundleURL`; enforces standard HTTPS with no port for the inference host; normalizes root-dot to the canonical host for both `baseURL` and `enclaveURL`.
- Throws a configuration error when `baseURL` is the inference origin and `enclaveURL` differs; generic proxies retain full endpoint/key rotation on `KeyConfigMismatchError`.
- Browser integration now makes a real models request and asserts `enclaveHost === "inference.tinfoil.sh"`.

**Migration**
- If `baseURL` is https://inference.tinfoil.sh, omit `enclaveURL` or set it to the same origin. To use another enclave, go through a proxy that forwards `X-Tinfoil-Enclave-Url` or connect directly.
- Ensure any `attestationBundleURL` uses HTTPS; non-HTTPS or non-standard ports for the inference origin now error.

<sup>Written for commit 3bcb1c10a646a78691d018190c5e94456a41633f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-js/pull/195?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

